### PR TITLE
fix(document): preserve rel attribute on links during parse and serialize

### DIFF
--- a/src/app/src/types/content.ts
+++ b/src/app/src/types/content.ts
@@ -3,7 +3,6 @@ import type { CollectionType } from '@nuxt/content'
 export interface MarkdownParsingOptions {
   compress?: boolean
   collectionType?: CollectionType
-  preserveLinkAttributes?: boolean
 }
 
 export interface SyntaxHighlightTheme {

--- a/src/module/src/runtime/utils/document/compare.ts
+++ b/src/module/src/runtime/utils/document/compare.ts
@@ -73,8 +73,8 @@ export function areDocumentsEqual(document1: Record<string, unknown>, document2:
     Reflect.deleteProperty(doc, '__hash__')
     Reflect.deleteProperty(doc, 'path')
 
-    // default value of navigation is true; D1 may store it as string 'true'
-    if (typeof doc.navigation === 'undefined' || doc.navigation === 'true') {
+    // default value of navigation is true
+    if (typeof doc.navigation === 'undefined') {
       doc.navigation = true
     }
 

--- a/src/module/src/runtime/utils/document/compare.ts
+++ b/src/module/src/runtime/utils/document/compare.ts
@@ -9,7 +9,7 @@ import { generateDocumentFromContent } from './generate'
 import { removeLastStylesFromTree } from './tree'
 
 export async function isDocumentMatchingContent(content: string, document: DatabaseItem): Promise<boolean> {
-  const generatedDocument = await generateDocumentFromContent(document.id, content, { compress: true, preserveLinkAttributes: true }) as DatabaseItem
+  const generatedDocument = await generateDocumentFromContent(document.id, content, { compress: true }) as DatabaseItem
 
   if (generatedDocument.extension === ContentFileExtension.Markdown) {
     const { body: generatedBody, ...generatedDocumentData } = generatedDocument
@@ -73,8 +73,8 @@ export function areDocumentsEqual(document1: Record<string, unknown>, document2:
     Reflect.deleteProperty(doc, '__hash__')
     Reflect.deleteProperty(doc, 'path')
 
-    // default value of navigation is true
-    if (typeof doc.navigation === 'undefined') {
+    // default value of navigation is true; D1 may store it as string 'true'
+    if (typeof doc.navigation === 'undefined' || doc.navigation === 'true') {
       doc.navigation = true
     }
 

--- a/src/module/src/runtime/utils/document/generate.ts
+++ b/src/module/src/runtime/utils/document/generate.ts
@@ -107,7 +107,6 @@ export async function generateDocumentFromMarkdownContent(id: string, content: s
     },
   })
 
-
   let body = document.body as never as MarkdownRoot
   if (options.compress && document.body.type === 'root') {
     body = compressTree(document.body)

--- a/src/module/src/runtime/utils/document/generate.ts
+++ b/src/module/src/runtime/utils/document/generate.ts
@@ -1,12 +1,10 @@
 import type { MarkdownRoot } from '@nuxt/content'
-import type { MDCElement, MDCRoot } from '@nuxtjs/mdc'
+import type { MDCRoot } from '@nuxtjs/mdc'
 import type { DatabaseItem, DatabasePageItem, MarkdownParsingOptions } from 'nuxt-studio/app'
-import type { Node } from 'unist'
 import { consola } from 'consola'
 import { ContentFileExtension } from '../../types/content'
 import { parseMarkdown } from '@nuxtjs/mdc/runtime/parser/index'
 import { stringifyMarkdown } from '@nuxtjs/mdc/runtime'
-import { visit } from 'unist-util-visit'
 import { compressTree, decompressTree } from '@nuxt/content/runtime'
 import destr from 'destr'
 import { parseFrontMatter, stringifyFrontMatter } from 'remark-mdc'
@@ -109,13 +107,6 @@ export async function generateDocumentFromMarkdownContent(id: string, content: s
     },
   })
 
-  // Remove nofollow from links (skip when preserving attributes for comparison purposes)
-  if (!options.preserveLinkAttributes) {
-    visit(document.body, (node: unknown) => (node as MDCElement).type === 'element' && (node as MDCElement).tag === 'a', (node: unknown) => {
-      // TODO: handle rel custom properties
-      Reflect.deleteProperty((node as MDCElement).props!, 'rel')
-    })
-  }
 
   let body = document.body as never as MarkdownRoot
   if (options.compress && document.body.type === 'root') {
@@ -176,12 +167,6 @@ export async function generateContentFromJSONDocument(document: DatabaseItem): P
 export async function generateContentFromMarkdownDocument(document: DatabaseItem): Promise<string | null> {
   // @ts-expect-error todo fix MarkdownRoot/MDCRoot conversion in MDC module
   const body = document.body!.type === 'minimark' ? decompressTree(document.body) : (document.body as MDCRoot)
-
-  // Remove nofollow from links
-  visit(body, (node: Node) => (node as MDCElement).type === 'element' && (node as MDCElement).tag === 'a', (node: Node) => {
-    // TODO: handle rel custom properties
-    Reflect.deleteProperty((node as MDCElement).props!, 'rel')
-  })
 
   const markdown = await stringifyMarkdown(body, cleanDataKeys(document), {
     frontMatter: {


### PR DESCRIPTION
## Description

Studio unconditionally strips the `rel` attribute from all `<a>` elements both when parsing markdown into a document and when serializing back to markdown. This causes MDC attributes like `{rel="nofollow"}` to be lost through Studio editing round-trips.

## Reproduction

1. Create a markdown file with a link that has a `rel` attribute:
   ```md
   [Example](https://example.com){rel="nofollow"}
   ```
2. Open in Studio and make any edit
3. Save/commit — the `{rel="nofollow"}` is stripped from the output

## Root Cause

Two `visit()` calls iterate all `<a>` elements and `Reflect.deleteProperty(node.props, 'rel')`:
- One in `generateDocumentFromMarkdownContent` (parse path)
- One in `generateContentFromMarkdownDocument` (serialize path)

The `preserveLinkAttributes` option was added as a partial workaround for comparison logic, but the stripping still happened during normal editing flows.

## Fix

Remove both `rel`-stripping `visit()` calls entirely. User-authored `rel` attributes should always be preserved through round-trips. The `preserveLinkAttributes` option is no longer needed and is removed.

## Changes

- `src/module/src/runtime/utils/document/generate.ts`: Remove both `visit()` calls that strip `rel`, clean up unused imports
- `src/module/src/runtime/utils/document/compare.ts`: Remove `preserveLinkAttributes: true` option (no longer needed)
- `src/app/src/types/content.ts`: Remove `preserveLinkAttributes` from `MarkdownParsingOptions`

## Impact

After this change, any `rel` attributes in MDC link syntax will survive Studio editing:
- `{rel="nofollow"}` — for SEO control
- `{rel="noopener"}` — for security
- `{rel="sponsored"}` — for affiliate links