### PR TITLE
docs: document branch auto-detection precedence

### DIFF
--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -146,7 +146,7 @@ When deploying on supported platforms, the repository details are **automaticall
 | **GitHub Actions** | `github`              | from `GITHUB_REPOSITORY` | from `GITHUB_REPOSITORY` | `GITHUB_REF_NAME`       |
 | **GitLab CI**      | `gitlab`              | `CI_PROJECT_NAMESPACE`   | `CI_PROJECT_NAME`        | `CI_COMMIT_BRANCH`      |
 
-Auto-detection only applies when `owner` and `repo` are not explicitly set. Any manually configured values always take precedence.
+Auto-detection applies to all fields, including `branch`. CI-detected values take precedence over manually configured values in `nuxt.config.ts`.
 
 To override or for unsupported platforms, configure the repository manually:
 

--- a/docs/content/3.git-providers.md
+++ b/docs/content/3.git-providers.md
@@ -56,7 +56,7 @@ When deploying on **Vercel**, **Netlify**, **GitHub Actions**, or **GitLab CI**,
 This means you can skip the `studio.repository` configuration entirely on these platforms — just set up your [Auth provider](/auth-providers) and deploy.
 
 ::note
-Auto-detection only applies when `owner` and `repo` are not set in your `nuxt.config.ts`. Any manually configured values always take precedence.
+Auto-detection applies to all fields, including `branch`. CI-detected values take precedence over manually configured values in `nuxt.config.ts`. To use a specific branch, unset the corresponding CI environment variable (e.g. `GITHUB_REF_NAME`) or configure your deployment platform accordingly.
 ::
 
 ::warning


### PR DESCRIPTION
## Summary

The docs claimed _"Any manually configured values always take precedence"_ over CI auto-detection, which contradicts the intentional behavior settled in #417. CI-detected values (e.g. `GITHUB_REF_NAME`) actually take precedence over `studio.repository` values in `nuxt.config.ts`.

## Changes

- `docs/content/3.git-providers.md` — corrected precedence note
- `docs/content/2.setup.md` — corrected precedence note

Resolves #471