### PR TITLE
fix(security): move secret env var reads from build time to runtime

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -95,8 +95,8 @@ Configure how users authenticate to access Studio. Choose from GitHub, GitLab, G
 
 ```bash
 # Example with GitHub OAuth
-STUDIO_GITHUB_CLIENT_ID=<your_client_id>
-STUDIO_GITHUB_CLIENT_SECRET=<your_client_secret>
+NUXT_STUDIO_AUTH_GITHUB_CLIENT_ID=<your_client_id>
+NUXT_STUDIO_AUTH_GITHUB_CLIENT_SECRET=<your_client_secret>
 ```
 
 > [📖 Auth Providers Documentation](https://nuxt.studio/auth-providers)

--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -75,8 +75,8 @@ Configure how users authenticate to access Studio. Choose from GitHub, GitLab, G
 
 ```bash [.env]
 # Example with GitHub OAuth
-STUDIO_GITHUB_CLIENT_ID=<your_client_id>
-STUDIO_GITHUB_CLIENT_SECRET=<your_client_secret>
+NUXT_STUDIO_AUTH_GITHUB_CLIENT_ID=<your_client_id>
+NUXT_STUDIO_AUTH_GITHUB_CLIENT_SECRET=<your_client_secret>
 ```
 
   :::tip{to="/auth-providers"}
@@ -184,7 +184,7 @@ export default defineNuxtConfig({
 ```
 
 ::note
-Can be overridden by the `STUDIO_GITHUB_INSTANCE_URL` or `STUDIO_GITLAB_INSTANCE_URL` environment variable.
+Can be overridden by the `NUXT_STUDIO_AUTH_GITHUB_INSTANCE_URL` or `NUXT_STUDIO_AUTH_GITLAB_INSTANCE_URL` environment variable.
 ::
 
 #### Root directory `default: ''`

--- a/docs/content/3.git-providers.md
+++ b/docs/content/3.git-providers.md
@@ -25,12 +25,12 @@ When using **GitHub OAuth** or **GitLab OAuth** as your [Auth provider](/auth-pr
 
 ```bash [.env]
 # GitHub OAuth - token is obtained automatically during login
-STUDIO_GITHUB_CLIENT_ID=<your_github_client_id>
-STUDIO_GITHUB_CLIENT_SECRET=<your_github_client_secret>
+NUXT_STUDIO_AUTH_GITHUB_CLIENT_ID=<your_github_client_id>
+NUXT_STUDIO_AUTH_GITHUB_CLIENT_SECRET=<your_github_client_secret>
 
 # Or GitLab OAuth - token is obtained automatically during login
-STUDIO_GITLAB_APPLICATION_ID=<your_gitlab_application_id>
-STUDIO_GITLAB_APPLICATION_SECRET=<your_gitlab_secret>
+NUXT_STUDIO_AUTH_GITLAB_APPLICATION_ID=<your_gitlab_application_id>
+NUXT_STUDIO_AUTH_GITLAB_APPLICATION_SECRET=<your_gitlab_secret>
 ```
 
 ### Personal Access Token (Manual)
@@ -39,10 +39,10 @@ When using **Google OAuth** or **Custom Auth** as your Auth provider, you must p
 
 ```bash [.env]
 # For GitHub repositories
-STUDIO_GITHUB_TOKEN=<your_github_personal_access_token>
+NUXT_STUDIO_GIT_GITHUB_TOKEN=<your_github_personal_access_token>
 
 # For GitLab repositories
-STUDIO_GITLAB_TOKEN=<your_gitlab_personal_access_token>
+NUXT_STUDIO_GIT_GITLAB_TOKEN=<your_gitlab_personal_access_token>
 ```
 
 ::tip
@@ -109,7 +109,7 @@ Fill in the required fields:
 Add the token to your deployment platform's environment variables:
 
 ```bash [.env]
-STUDIO_GITHUB_TOKEN=<your_github_personal_access_token>
+NUXT_STUDIO_GIT_GITHUB_TOKEN=<your_github_personal_access_token>
 ```
 ::
 
@@ -133,7 +133,7 @@ export default defineNuxtConfig({
 ::note
 **Self hosted GitLab**:
 
-- You can use the `STUDIO_GITLAB_INSTANCE_URL` to override the default GitLab instance URL if you're using a self-hosted instance.
+- You can use the `NUXT_STUDIO_AUTH_GITLAB_INSTANCE_URL` to override the default GitLab instance URL if you're using a self-hosted instance.
 - [Oauth instance URL](/auth-providers#set-gitlab-environment-variables) is based on the same env variable by default.
 ::
 
@@ -161,7 +161,7 @@ Fill in the required fields:
 Add the token to your deployment platform's environment variables:
 
 ```bash [.env]
-STUDIO_GITLAB_TOKEN=<your_gitlab_personal_access_token>
+NUXT_STUDIO_GIT_GITLAB_TOKEN=<your_gitlab_personal_access_token>
 ```
 ::
 
@@ -177,7 +177,7 @@ This is useful when you want to review changes on a preview environment before m
 Update your `nuxt.config.ts` to target your staging branch.
 
   :::tip
-  You can use environment variables to manage multiple branches for different environments.
+  Set `NUXT_PUBLIC_STUDIO_REPOSITORY_BRANCH` at deployment time to configure the branch per environment without rebuilding.
   :::
 
 ```ts [nuxt.config.ts]
@@ -186,7 +186,7 @@ export default defineNuxtConfig({
     repository: {
       owner: 'your-username',
       repo: 'your-repo',
-      branch: process.env.STUDIO_BRANCH_NAME || 'main'
+      branch: 'main' // override at runtime via NUXT_PUBLIC_STUDIO_REPOSITORY_BRANCH
     }
   }
 })

--- a/docs/content/4.auth-providers.md
+++ b/docs/content/4.auth-providers.md
@@ -67,14 +67,14 @@ After creating the OAuth app, you'll receive:
 Add the GitHub OAuth credentials to your deployment platform's environment variables or `.env` file:
 
 ```bash [.env]
-STUDIO_GITHUB_CLIENT_ID=<your_github_client_id>
-STUDIO_GITHUB_CLIENT_SECRET=<your_github_client_secret>
+NUXT_STUDIO_AUTH_GITHUB_CLIENT_ID=<your_github_client_id>
+NUXT_STUDIO_AUTH_GITHUB_CLIENT_SECRET=<your_github_client_secret>
 
 # Optional: Restrict access to specific users
-# STUDIO_GITHUB_MODERATORS=admin@example.com,editor@example.com
+# NUXT_STUDIO_AUTH_GITHUB_MODERATORS=admin@example.com,editor@example.com
 
 # Optional: GitHub entreprise server
-STUDIO_GITHUB_INSTANCE_URL=https://gh-ent.com
+NUXT_STUDIO_AUTH_GITHUB_INSTANCE_URL=https://gh-ent.com
 ```
 ::
 
@@ -111,14 +111,14 @@ After creating the OAuth application, you'll receive:
 Add the GitLab OAuth credentials to your deployment platform's environment variables or `.env` file:
 
 ```bash [.env]
-STUDIO_GITLAB_APPLICATION_ID=<your_gitlab_application_id>
-STUDIO_GITLAB_APPLICATION_SECRET=<your_gitlab_secret>
+NUXT_STUDIO_AUTH_GITLAB_APPLICATION_ID=<your_gitlab_application_id>
+NUXT_STUDIO_AUTH_GITLAB_APPLICATION_SECRET=<your_gitlab_secret>
 
 # Optional: Restrict access to specific users
-# STUDIO_GITLAB_MODERATORS=admin@example.com,editor@example.com
+# NUXT_STUDIO_AUTH_GITLAB_MODERATORS=admin@example.com,editor@example.com
 
 # Optional: Self hosted GitLab server
-STUDIO_GITLAB_INSTANCE_URL=https://gh-ent.com
+NUXT_STUDIO_AUTH_GITLAB_INSTANCE_URL=https://gh-ent.com
 ```
 ::
 
@@ -164,25 +164,25 @@ Add the Google OAuth credentials, your personal access token and moderator list:
   :::tabs
     ::::tabs-item{icon="i-lucide-github" label="With GitHub Repository"}
     ```bash [.env]
-    STUDIO_GOOGLE_CLIENT_ID=<your_google_client_id>
-    STUDIO_GOOGLE_CLIENT_SECRET=<your_google_client_secret>
-    STUDIO_GITHUB_TOKEN=<your_github_personal_access_token>
-    STUDIO_GOOGLE_MODERATORS=admin@example.com,editor@example.com
+    NUXT_STUDIO_AUTH_GOOGLE_CLIENT_ID=<your_google_client_id>
+    NUXT_STUDIO_AUTH_GOOGLE_CLIENT_SECRET=<your_google_client_secret>
+    NUXT_STUDIO_GIT_GITHUB_TOKEN=<your_github_personal_access_token>
+    NUXT_STUDIO_AUTH_GOOGLE_MODERATORS=admin@example.com,editor@example.com
     ```
     ::::
 
     ::::tabs-item{icon="i-lucide-gitlab" label="With GitLab Repository"}
     ```bash [.env]
-    STUDIO_GOOGLE_CLIENT_ID=<your_google_client_id>
-    STUDIO_GOOGLE_CLIENT_SECRET=<your_google_client_secret>
-    STUDIO_GITLAB_TOKEN=<your_gitlab_personal_access_token>
-    STUDIO_GOOGLE_MODERATORS=admin@example.com,editor@example.com
+    NUXT_STUDIO_AUTH_GOOGLE_CLIENT_ID=<your_google_client_id>
+    NUXT_STUDIO_AUTH_GOOGLE_CLIENT_SECRET=<your_google_client_secret>
+    NUXT_STUDIO_GIT_GITLAB_TOKEN=<your_gitlab_personal_access_token>
+    NUXT_STUDIO_AUTH_GOOGLE_MODERATORS=admin@example.com,editor@example.com
     ```
     ::::
   :::
 
   :::warning
-  The `STUDIO_GOOGLE_MODERATORS` environment variable is **required** for Google OAuth. Only users with email addresses in this list can access Studio.
+  The `NUXT_STUDIO_AUTH_GOOGLE_MODERATORS` environment variable is **required** for Google OAuth. Only users with email addresses in this list can access Studio.
   :::
 ::
 
@@ -214,9 +214,9 @@ Deploy [Nuxt Studio SSO](https://github.com/nuxt-content/nuxt-studio-sso) to you
 Add the SSO credentials to your deployment platform's environment variables:
 
 ```bash [.env]
-STUDIO_SSO_URL=https://your-sso-server.com
-STUDIO_SSO_CLIENT_ID=<your_client_id>
-STUDIO_SSO_CLIENT_SECRET=<your_client_secret>
+NUXT_STUDIO_AUTH_SSO_SERVER_URL=https://your-sso-server.com
+NUXT_STUDIO_AUTH_SSO_CLIENT_ID=<your_client_id>
+NUXT_STUDIO_AUTH_SSO_CLIENT_SECRET=<your_client_secret>
 ```
 
   :::note
@@ -242,10 +242,10 @@ You must configure a Personal Access Token for repository operations based on th
 
 ```bash [.env]
 # For GitHub repositories
-STUDIO_GITHUB_TOKEN=<your_github_personal_access_token>
+NUXT_STUDIO_GIT_GITHUB_TOKEN=<your_github_personal_access_token>
 
 # For GitLab repositories
-STUDIO_GITLAB_TOKEN=<your_gitlab_personal_access_token>
+NUXT_STUDIO_GIT_GITLAB_TOKEN=<your_gitlab_personal_access_token>
 ```
 
 See [Git Providers](/git-providers#creating-a-personal-access-token) for instructions on creating a PAT.
@@ -323,17 +323,17 @@ return sendRedirect(event, '/')
 
 ### Access Control with Moderators
 
-You can restrict access to Studio by defining a whitelist of authorized users through the `STUDIO_{PROVIDER}_MODERATORS` environment variable.
+You can restrict access to Studio by defining a whitelist of authorized users through the `NUXT_STUDIO_AUTH_{PROVIDER}_MODERATORS` environment variable.
 
 ```bash [.env]
 # GitHub OAuth moderators
-STUDIO_GITHUB_MODERATORS=admin@example.com,editor@example.com
+NUXT_STUDIO_AUTH_GITHUB_MODERATORS=admin@example.com,editor@example.com
 
 # GitLab OAuth moderators
-STUDIO_GITLAB_MODERATORS=admin@example.com,editor@example.com
+NUXT_STUDIO_AUTH_GITLAB_MODERATORS=admin@example.com,editor@example.com
 
 # Google OAuth moderators (required)
-STUDIO_GOOGLE_MODERATORS=admin@example.com,editor@example.com
+NUXT_STUDIO_AUTH_GOOGLE_MODERATORS=admin@example.com,editor@example.com
 ```
 
 The moderator list is a comma-separated list of email addresses. Only users with matching email addresses will be granted access.
@@ -357,13 +357,13 @@ By default, Studio uses your deployment URL for OAuth callbacks. To customize th
 
 ```bash [.env]
 # GitHub OAuth
-STUDIO_GITHUB_REDIRECT_URL=https://custom-domain.com/__nuxt_studio/auth/github
+NUXT_STUDIO_AUTH_GITHUB_REDIRECT_URL=https://custom-domain.com/__nuxt_studio/auth/github
 
 # GitLab OAuth
-STUDIO_GITLAB_REDIRECT_URL=https://custom-domain.com/__nuxt_studio/auth/gitlab
+NUXT_STUDIO_AUTH_GITLAB_REDIRECT_URL=https://custom-domain.com/__nuxt_studio/auth/gitlab
 
 # Google OAuth
-STUDIO_GOOGLE_REDIRECT_URL=https://custom-domain.com/__nuxt_studio/auth/google
+NUXT_STUDIO_AUTH_GOOGLE_REDIRECT_URL=https://custom-domain.com/__nuxt_studio/auth/google
 ```
 
 ::note

--- a/docs/content/6.medias.md
+++ b/docs/content/6.medias.md
@@ -111,7 +111,7 @@ export default defineNuxtConfig({
     S3_SECRET_ACCESS_KEY=your-secret-access-key
     S3_BUCKET=your-bucket-name
     S3_REGION=your-region # (optional)
-    S3_PUBLIC_URL=your-public-url # (optional, mandatory for Cloudflare R2 provider)
+    NUXT_PUBLIC_STUDIO_MEDIA_PUBLIC_URL=your-public-url # (optional, mandatory for Cloudflare R2 provider)
     S3_ENDPOINT=your-endpoint
     ```
     ::::
@@ -244,7 +244,7 @@ S3_ACCESS_KEY_ID=<r2_access_key_id>
 S3_SECRET_ACCESS_KEY=<r2_secret_access_key>
 S3_ENDPOINT=https://<account_id>.r2.cloudflarestorage.com
 S3_BUCKET=my-studio-media
-S3_PUBLIC_URL=https://pub-<hash>.r2.dev   # or your custom domain
+NUXT_PUBLIC_STUDIO_MEDIA_PUBLIC_URL=https://pub-<hash>.r2.dev   # or your custom domain
 ```
 
 #### Enable and configure NuxtHub

--- a/docs/content/7.ai.md
+++ b/docs/content/7.ai.md
@@ -46,10 +46,10 @@ Generate a new API key from the AI Gateway dashboard.
 
 ### Set Environment Variable
 
-To enable AI-powered editing in Studio, simply set the `AI_GATEWAY_API_KEY` environment variable.
+To enable AI-powered editing in Studio, simply set the `NUXT_STUDIO_AI_API_KEY` environment variable.
 
 ```bash [.env]
-AI_GATEWAY_API_KEY=your_vercel_ai_gateway_api_key
+NUXT_STUDIO_AI_API_KEY=your_vercel_ai_gateway_api_key
 ```
 
 ### Contextualization

--- a/src/module/src/auth.ts
+++ b/src/module/src/auth.ts
@@ -7,50 +7,52 @@ export function validateAuthConfig(options: ModuleOptions): void {
   const provider = options.repository?.provider || 'github'
   const providerUpperCase = provider.toUpperCase()
 
-  // Git Token is enough for custom authentication
-  const hasGitToken = process.env.STUDIO_GITHUB_TOKEN || process.env.STUDIO_GITLAB_TOKEN
-  if (hasGitToken) {
-    return
-  }
-
   const hasGitHubAuth = options.auth?.github?.clientId && options.auth?.github?.clientSecret
   const hasGitLabAuth = options.auth?.gitlab?.applicationId && options.auth?.gitlab?.applicationSecret
   const hasGoogleAuth = options.auth?.google?.clientId && options.auth?.google?.clientSecret
   const hasSSOServer = options.auth?.sso?.serverUrl && options.auth?.sso?.clientId && options.auth?.sso?.clientSecret
-  const hasGoogleModerators = (process.env.STUDIO_GOOGLE_MODERATORS?.split(',') || []).length > 0
 
   // SSO server enabled - GitHub token is passed through from SSO when users login with GitHub
   if (hasSSOServer) {
     return
   }
 
+  // Git Token is enough for custom authentication — it can be supplied at runtime via
+  // STUDIO_GITHUB_TOKEN / STUDIO_GITLAB_TOKEN or NUXT_STUDIO_GIT_GITHUB_TOKEN so we
+  // can't reliably check it at build time.  Skip the guard here and let the auth route
+  // handlers surface a clear error at request time when no token is present.
+
   // Google OAuth enabled
   if (hasGoogleAuth) {
-    // Google OAuth moderators required
-    if (!hasGoogleModerators) {
-      logger.error([
-        'The `STUDIO_GOOGLE_MODERATORS` environment variable is required when using Google OAuth.',
-        'Please set the `STUDIO_GOOGLE_MODERATORS` environment variable to a comma-separated list of email of the allowed users.',
-        'Only users with these email addresses will be able to access studio with Google OAuth.',
+    // Google OAuth moderators are required but may be supplied at runtime via
+    // STUDIO_GOOGLE_MODERATORS — warn at build time when they're not in nuxt.config,
+    // but don't error (they may be set in the deployment environment).
+    const hasGoogleModeratorsInConfig = (options.auth?.google as { moderators?: string })?.moderators
+    if (!hasGoogleModeratorsInConfig) {
+      logger.warn([
+        'Google OAuth moderators are required when using Google OAuth.',
+        'Set `auth.google.moderators` in nuxt.config.ts or supply the `STUDIO_GOOGLE_MODERATORS`',
+        'environment variable (comma-separated list of allowed email addresses) at runtime.',
+        'Only users with these email addresses will be able to access Studio with Google OAuth.',
       ].join('\n'))
     }
 
-    // PAT required for pushing changes to the repository
-    if (!hasGitToken) {
-      logger.warn([
-        `The \`STUDIO_${providerUpperCase}_TOKEN\` environment variable is required when using Google OAuth with ${providerUpperCase} provider.`,
-        `This token is used to push changes to the repository when using Google OAuth.`,
-      ].join('\n'))
-    }
+    // A PAT is required for pushing changes — remind at build time, but it may be runtime-supplied.
+    logger.info([
+      `A \`STUDIO_${providerUpperCase}_TOKEN\` (or \`NUXT_STUDIO_GIT_${providerUpperCase}_TOKEN\`) is required`,
+      `when using Google OAuth with the ${providerUpperCase} provider so Studio can push changes to the repository.`,
+    ].join(' '))
   }
-  // Google OAuth disabled => GitHub or GitLab OAuth required
+  // Google OAuth disabled => GitHub or GitLab OAuth required (or runtime-supplied token)
   else {
-    const missingProviderEnv = provider === 'github' ? !hasGitHubAuth : !hasGitLabAuth
-    if (missingProviderEnv) {
+    const hasProviderAuth = provider === 'github' ? hasGitHubAuth : hasGitLabAuth
+    if (!hasProviderAuth) {
       logger.warn([
         `In order to use Studio in production mode, you need to setup authentication:`,
         '- Read more on `https://nuxt.studio/auth-providers`',
         `- Alternatively, you can disable studio by setting \`$production: { studio: false }\` in your \`nuxt.config.ts\``,
+        `- Auth credentials can also be supplied at runtime via STUDIO_${providerUpperCase}_CLIENT_ID / STUDIO_${providerUpperCase}_CLIENT_SECRET`,
+        `  or a personal access token via STUDIO_${providerUpperCase}_TOKEN.`,
       ].join('\n'))
     }
   }

--- a/src/module/src/auth.ts
+++ b/src/module/src/auth.ts
@@ -12,47 +12,34 @@ export function validateAuthConfig(options: ModuleOptions): void {
   const hasGoogleAuth = options.auth?.google?.clientId && options.auth?.google?.clientSecret
   const hasSSOServer = options.auth?.sso?.serverUrl && options.auth?.sso?.clientId && options.auth?.sso?.clientSecret
 
-  // SSO server enabled - GitHub token is passed through from SSO when users login with GitHub
   if (hasSSOServer) {
     return
   }
 
-  // Git Token is enough for custom authentication — it can be supplied at runtime via
-  // STUDIO_GITHUB_TOKEN / STUDIO_GITLAB_TOKEN or NUXT_STUDIO_GIT_GITHUB_TOKEN so we
-  // can't reliably check it at build time.  Skip the guard here and let the auth route
-  // handlers surface a clear error at request time when no token is present.
-
-  // Google OAuth enabled
   if (hasGoogleAuth) {
-    // Google OAuth moderators are required but may be supplied at runtime via
-    // STUDIO_GOOGLE_MODERATORS — warn at build time when they're not in nuxt.config,
-    // but don't error (they may be set in the deployment environment).
     const hasGoogleModeratorsInConfig = (options.auth?.google as { moderators?: string })?.moderators
     if (!hasGoogleModeratorsInConfig) {
       logger.warn([
         'Google OAuth moderators are required when using Google OAuth.',
-        'Set `auth.google.moderators` in nuxt.config.ts or supply the `STUDIO_GOOGLE_MODERATORS`',
-        'environment variable (comma-separated list of allowed email addresses) at runtime.',
+        'Set `auth.google.moderators` in nuxt.config.ts or supply `NUXT_STUDIO_AUTH_GOOGLE_MODERATORS`',
+        '(comma-separated list of allowed email addresses) at runtime.',
         'Only users with these email addresses will be able to access Studio with Google OAuth.',
       ].join('\n'))
     }
-
-    // A PAT is required for pushing changes — remind at build time, but it may be runtime-supplied.
     logger.info([
-      `A \`STUDIO_${providerUpperCase}_TOKEN\` (or \`NUXT_STUDIO_GIT_${providerUpperCase}_TOKEN\`) is required`,
-      `when using Google OAuth with the ${providerUpperCase} provider so Studio can push changes to the repository.`,
+      `A \`NUXT_STUDIO_GIT_${providerUpperCase}_TOKEN\` is required when using Google OAuth`,
+      `so Studio can push changes to the ${providerUpperCase} repository.`,
     ].join(' '))
   }
-  // Google OAuth disabled => GitHub or GitLab OAuth required (or runtime-supplied token)
   else {
     const hasProviderAuth = provider === 'github' ? hasGitHubAuth : hasGitLabAuth
     if (!hasProviderAuth) {
       logger.warn([
-        `In order to use Studio in production mode, you need to setup authentication:`,
+        'In order to use Studio in production mode, you need to setup authentication:',
         '- Read more on `https://nuxt.studio/auth-providers`',
-        `- Alternatively, you can disable studio by setting \`$production: { studio: false }\` in your \`nuxt.config.ts\``,
-        `- Auth credentials can also be supplied at runtime via STUDIO_${providerUpperCase}_CLIENT_ID / STUDIO_${providerUpperCase}_CLIENT_SECRET`,
-        `  or a personal access token via STUDIO_${providerUpperCase}_TOKEN.`,
+        '- Alternatively, you can disable studio by setting `$production: { studio: false }` in your `nuxt.config.ts`',
+        `- Auth credentials can also be supplied at runtime via NUXT_STUDIO_AUTH_${providerUpperCase}_CLIENT_ID / NUXT_STUDIO_AUTH_${providerUpperCase}_CLIENT_SECRET`,
+        `  or a personal access token via NUXT_STUDIO_GIT_${providerUpperCase}_TOKEN.`,
       ].join('\n'))
     }
   }

--- a/src/module/src/module.ts
+++ b/src/module/src/module.ts
@@ -87,7 +87,7 @@ interface MediaUploadOptions {
   /**
    * The public CDN URL for the media files.
    * Falls back to the blob URL returned by the storage provider if not set.
-   * @default process.env.S3_PUBLIC_URL
+   * @default NUXT_PUBLIC_STUDIO_MEDIA_PUBLIC_URL
    */
   publicUrl?: string
 
@@ -161,10 +161,7 @@ export interface ModuleOptions {
      * The Vercel AI Gateway key for AI features.
      * When set, AI-powered content generation will be enabled.
      *
-     * Resolution order (highest to lowest priority):
-     * 1. This option in nuxt.config.ts
-     * 2. `NUXT_STUDIO_AI_API_KEY` environment variable (Nuxt runtime override)
-     * 3. `AI_GATEWAY_API_KEY` environment variable (legacy, resolved at runtime)
+     * Set via `NUXT_STUDIO_AI_API_KEY` environment variable at runtime.
      */
     apiKey?: string
     /**
@@ -229,12 +226,12 @@ export interface ModuleOptions {
     github?: {
       /**
        * The GitHub OAuth client ID.
-       * @default process.env.STUDIO_GITHUB_CLIENT_ID
+       * @default NUXT_STUDIO_AUTH_GITHUB_CLIENT_ID
        */
       clientId?: string
       /**
        * The GitHub OAuth client secret.
-       * @default process.env.STUDIO_GITHUB_CLIENT_SECRET
+       * @default NUXT_STUDIO_AUTH_GITHUB_CLIENT_SECRET
        */
       clientSecret?: string
       /**
@@ -244,6 +241,11 @@ export interface ModuleOptions {
        * @default 'https://github.com'
        */
       instanceUrl?: string
+      /**
+       * Comma-separated list of allowed email addresses.
+       * @default NUXT_STUDIO_AUTH_GITHUB_MODERATORS
+       */
+      moderators?: string
     }
     /**
      * The GitLab OAuth credentials.
@@ -251,12 +253,12 @@ export interface ModuleOptions {
     gitlab?: {
       /**
        * The GitLab OAuth application ID.
-       * @default process.env.STUDIO_GITLAB_APPLICATION_ID
+       * @default NUXT_STUDIO_AUTH_GITLAB_APPLICATION_ID
        */
       applicationId?: string
       /**
        * The GitLab OAuth application secret.
-       * @default process.env.STUDIO_GITLAB_APPLICATION_SECRET
+       * @default NUXT_STUDIO_AUTH_GITLAB_APPLICATION_SECRET
        */
       applicationSecret?: string
       /**
@@ -264,45 +266,56 @@ export interface ModuleOptions {
        * @default 'https://gitlab.com'
        */
       instanceUrl?: string
+      /**
+       * Comma-separated list of allowed email addresses.
+       * @default NUXT_STUDIO_AUTH_GITLAB_MODERATORS
+       */
+      moderators?: string
     }
     /**
      * The Google OAuth credentials.
-     * Note: When using Google OAuth, you must set STUDIO_GOOGLE_MODERATORS to a comma-separated
-     * list of authorized email addresses, and either STUDIO_GITHUB_TOKEN or STUDIO_GITLAB_TOKEN
+     * Note: When using Google OAuth, you must set NUXT_STUDIO_AUTH_GOOGLE_MODERATORS to a comma-separated
+     * list of authorized email addresses, and either NUXT_STUDIO_GIT_GITHUB_TOKEN or NUXT_STUDIO_GIT_GITLAB_TOKEN
      * to push changes to your repository.
      */
     google?: {
       /**
        * The Google OAuth client ID.
-       * @default process.env.STUDIO_GOOGLE_CLIENT_ID
+       * @default NUXT_STUDIO_AUTH_GOOGLE_CLIENT_ID
        */
       clientId?: string
       /**
        * The Google OAuth client secret.
-       * @default process.env.STUDIO_GOOGLE_CLIENT_SECRET
+       * @default NUXT_STUDIO_AUTH_GOOGLE_CLIENT_SECRET
        */
       clientSecret?: string
+      /**
+       * Comma-separated list of authorized email addresses.
+       * Required when using Google OAuth.
+       * @default NUXT_STUDIO_AUTH_GOOGLE_MODERATORS
+       */
+      moderators?: string
     }
     /**
      * SSO server credentials for Single Sign-On across multiple Nuxt Studio sites.
      * This enables authentication via a centralized SSO server (like nuxt-studio-sso).
      * When users authenticate with GitHub on the SSO server, their GitHub token is
-     * automatically passed through, eliminating the need for STUDIO_GITHUB_TOKEN.
+     * automatically passed through, eliminating the need for NUXT_STUDIO_GIT_GITHUB_TOKEN.
      */
     sso?: {
       /**
        * The SSO server URL (e.g., 'https://auth.example.com').
-       * @default process.env.STUDIO_SSO_URL
+       * @default NUXT_STUDIO_AUTH_SSO_SERVER_URL
        */
       serverUrl?: string
       /**
        * The SSO client ID.
-       * @default process.env.STUDIO_SSO_CLIENT_ID
+       * @default NUXT_STUDIO_AUTH_SSO_CLIENT_ID
        */
       clientId?: string
       /**
        * The SSO client secret.
-       * @default process.env.STUDIO_SSO_CLIENT_SECRET
+       * @default NUXT_STUDIO_AUTH_SSO_CLIENT_SECRET
        */
       clientSecret?: string
     }
@@ -514,7 +527,7 @@ export default defineNuxtModule<ModuleOptions>({
       },
       ai: {
         // Honest build-time baseline; the studio-env middleware recomputes this at runtime
-        // once the AI_GATEWAY_API_KEY / NUXT_STUDIO_AI_API_KEY is resolved.
+        // once NUXT_STUDIO_AI_API_KEY is resolved.
         enabled: Boolean(options.ai?.apiKey),
         context: {
           collectionName: options.ai?.context?.collection?.name as string,

--- a/src/module/src/module.ts
+++ b/src/module/src/module.ts
@@ -1,5 +1,4 @@
 import { defineNuxtModule, createResolver, addPlugin, extendViteConfig, addServerHandler, addServerImports, useLogger, hasNuxtModule } from '@nuxt/kit'
-import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { defu } from 'defu'
@@ -159,9 +158,13 @@ export interface ModuleOptions {
    */
   ai?: {
     /**
-     * The Vercel API Gateway key for AI features.
+     * The Vercel AI Gateway key for AI features.
      * When set, AI-powered content generation will be enabled.
-     * @default process.env.AI_GATEWAY_API_KEY
+     *
+     * Resolution order (highest to lowest priority):
+     * 1. This option in nuxt.config.ts
+     * 2. `NUXT_STUDIO_AI_API_KEY` environment variable (Nuxt runtime override)
+     * 3. `AI_GATEWAY_API_KEY` environment variable (legacy, resolved at runtime)
      */
     apiKey?: string
     /**
@@ -390,27 +393,27 @@ export default defineNuxtModule<ModuleOptions>({
       branch: undefined,
       rootDir: '',
       private: true,
-      instanceUrl: process.env.STUDIO_GITHUB_INSTANCE_URL || process.env.STUDIO_GITLAB_INSTANCE_URL,
+      instanceUrl: undefined,
     },
     auth: {
       github: {
-        clientId: process.env.STUDIO_GITHUB_CLIENT_ID,
-        clientSecret: process.env.STUDIO_GITHUB_CLIENT_SECRET,
-        instanceUrl: process.env.STUDIO_GITHUB_INSTANCE_URL || 'https://github.com',
+        clientId: undefined,
+        clientSecret: undefined,
+        instanceUrl: 'https://github.com',
       },
       gitlab: {
-        applicationId: process.env.STUDIO_GITLAB_APPLICATION_ID,
-        applicationSecret: process.env.STUDIO_GITLAB_APPLICATION_SECRET,
-        instanceUrl: process.env.STUDIO_GITLAB_INSTANCE_URL || 'https://gitlab.com',
+        applicationId: undefined,
+        applicationSecret: undefined,
+        instanceUrl: 'https://gitlab.com',
       },
       google: {
-        clientId: process.env.STUDIO_GOOGLE_CLIENT_ID,
-        clientSecret: process.env.STUDIO_GOOGLE_CLIENT_SECRET,
+        clientId: undefined,
+        clientSecret: undefined,
       },
       sso: {
-        serverUrl: process.env.STUDIO_SSO_URL,
-        clientId: process.env.STUDIO_SSO_CLIENT_ID,
-        clientSecret: process.env.STUDIO_SSO_CLIENT_SECRET,
+        serverUrl: undefined,
+        clientId: undefined,
+        clientSecret: undefined,
       },
     },
     i18n: {
@@ -434,7 +437,7 @@ export default defineNuxtModule<ModuleOptions>({
     },
     media: {
       external: false,
-      publicUrl: process.env.S3_PUBLIC_URL,
+      publicUrl: undefined,
       maxFileSize: 10 * 1024 * 1024,
       allowedTypes: ['image/*', 'video/*', 'audio/*'],
       prefix: 'studio',
@@ -460,38 +463,27 @@ export default defineNuxtModule<ModuleOptions>({
       options.dev = false
     }
 
-    // Fill in missing repository options from CI environment variables
     const isProdBuild = nuxt.options.dev === false && nuxt.options._prepare === false
-    if (isProdBuild) {
-      const detectedRepo = detectRepositoryFromCI()
-      if (detectedRepo) {
-        // Do not override provider with CI detection
-        // For other fields CI detection values take precedence over user-configured values
-        const { provider: detectedProvider, ...detectedWithoutProvider } = detectedRepo
-        options.repository = defu(detectedWithoutProvider, options.repository) as GitHubRepositoryOptions | GitLabRepositoryOptions
-        if (!options.repository.provider) {
-          (options.repository as GitHubRepositoryOptions | GitLabRepositoryOptions).provider = detectedProvider as 'github' | 'gitlab'
-        }
-      }
-      logger.info(`Using repository: ${options.repository?.provider}:${options.repository?.owner}/${options.repository?.repo}#${options.repository?.branch}`)
+
+    if (isProdBuild && options.repository?.owner && options.repository?.repo) {
+      logger.info(`Using repository (build-time config): ${options.repository?.provider}:${options.repository?.owner}/${options.repository?.repo}#${options.repository?.branch}`)
     }
 
     if (isProdBuild && !options.repository?.owner && !options.repository?.repo) {
-      throw new Error('Repository owner and repository name are required')
+      logger.warn([
+        'Repository owner and repository name are not configured at build time.',
+        'They can be supplied at runtime via:',
+        '  - NUXT_PUBLIC_STUDIO_REPOSITORY_OWNER / NUXT_PUBLIC_STUDIO_REPOSITORY_REPO / NUXT_PUBLIC_STUDIO_REPOSITORY_BRANCH',
+        '  - CI platform env vars: VERCEL_GIT_* or Netlify REPOSITORY_URL / BRANCH (resolved at server runtime)',
+        'Note: GITHUB_ACTIONS / GITLAB_CI env vars are build-time only; use NUXT_PUBLIC_STUDIO_REPOSITORY_* for those deployments.',
+      ].join('\n'))
     }
 
     if (isProdBuild) {
       validateAuthConfig(options)
     }
 
-    // Read AI API key from environment if not provided in options
-    if (!options.ai?.apiKey && process.env.AI_GATEWAY_API_KEY) {
-      options.ai = options.ai || {}
-      options.ai.apiKey = process.env.AI_GATEWAY_API_KEY
-    }
-
-    const isAIEnabled = Boolean(options.ai?.apiKey)
-    if (isAIEnabled) {
+    if (options.ai) {
       await setAIFeature(options, nuxt, runtime)
     }
 
@@ -509,10 +501,8 @@ export default defineNuxtModule<ModuleOptions>({
       }
     }
 
-    if (!options.media!.publicUrl) {
-      options.media!.publicUrl = isExternalMediaEnabled
-        ? process.env.S3_PUBLIC_URL
-        : resolve(nuxt.options.rootDir, 'public')
+    if (!isExternalMediaEnabled && !options.media!.publicUrl) {
+      options.media!.publicUrl = resolve(nuxt.options.rootDir, 'public')
     }
 
     // Public runtime config
@@ -523,6 +513,8 @@ export default defineNuxtModule<ModuleOptions>({
         server: process.env.STUDIO_DEV_SERVER,
       },
       ai: {
+        // Honest build-time baseline; the studio-env middleware recomputes this at runtime
+        // once the AI_GATEWAY_API_KEY / NUXT_STUDIO_AI_API_KEY is resolved.
         enabled: Boolean(options.ai?.apiKey),
         context: {
           collectionName: options.ai?.context?.collection?.name as string,
@@ -546,32 +538,43 @@ export default defineNuxtModule<ModuleOptions>({
     // Studio runtime config
     nuxt.options.runtimeConfig.studio = {
       ai: {
-        apiKey: options.ai?.apiKey,
+        apiKey: options.ai?.apiKey || '',
         context: options.ai?.context as never,
         experimental: options.ai?.experimental,
       },
       auth: {
-        sessionSecret: createHash('md5').update([
-          options.auth?.github?.clientId,
-          options.auth?.github?.clientSecret,
-          options.auth?.gitlab?.applicationId,
-          options.auth?.gitlab?.applicationSecret,
-          options.auth?.google?.clientId,
-          options.auth?.google?.clientSecret,
-          options.auth?.sso?.serverUrl,
-          options.auth?.sso?.clientId,
-          options.auth?.sso?.clientSecret,
-          process.env.STUDIO_GITHUB_TOKEN,
-          process.env.STUDIO_GITLAB_TOKEN,
-        ].join('')).digest('hex'),
-        // @ts-expect-error autogenerated type doesn't match with project options
-        github: options.auth?.github,
-        // @ts-expect-error autogenerated type doesn't match with project options
-        gitlab: options.auth?.gitlab,
-        // @ts-expect-error autogenerated type doesn't match with project options
-        google: options.auth?.google,
-        // @ts-expect-error autogenerated type doesn't match with project options
-        sso: options.auth?.sso,
+        sessionSecret: '',
+        github: {
+          clientId: options.auth?.github?.clientId || '',
+          clientSecret: options.auth?.github?.clientSecret || '',
+          instanceUrl: options.auth!.github!.instanceUrl!,
+          redirectUrl: '',
+          moderators: '',
+        },
+        gitlab: {
+          applicationId: options.auth?.gitlab?.applicationId || '',
+          applicationSecret: options.auth?.gitlab?.applicationSecret || '',
+          instanceUrl: options.auth!.gitlab!.instanceUrl!,
+          redirectUrl: '',
+          moderators: '',
+        },
+        google: {
+          clientId: options.auth?.google?.clientId || '',
+          clientSecret: options.auth?.google?.clientSecret || '',
+          redirectUrl: '',
+          moderators: '',
+        },
+        sso: {
+          serverUrl: options.auth?.sso?.serverUrl || '',
+          clientId: options.auth?.sso?.clientId || '',
+          clientSecret: options.auth?.sso?.clientSecret || '',
+          redirectUrl: '',
+        },
+      },
+      git: {
+        commit: { messagePrefix: options.git?.commit?.messagePrefix ?? '' },
+        githubToken: '',
+        gitlabToken: '',
       },
       // @ts-expect-error Autogenerated type does not match with options
       repository: options.repository,
@@ -579,6 +582,11 @@ export default defineNuxtModule<ModuleOptions>({
       editor: editorOptions,
       // @ts-expect-error Autogenerated type does not match with options
       markdown: nuxt.options.content?.build?.markdown || {},
+      // @ts-expect-error Autogenerated type does not match with options (optional booleans vs required)
+      media: {
+        ...options.media,
+        publicUrl: options.media?.publicUrl || '',
+      },
     }
 
     // Vite config
@@ -639,6 +647,8 @@ export default defineNuxtModule<ModuleOptions>({
     addPlugin(process.env.STUDIO_DEV_SERVER
       ? runtime('./plugins/studio.client.dev')
       : runtime('./plugins/studio.client'))
+
+    addServerHandler({ middleware: true, handler: runtime('./server/middleware/studio-env') })
 
     let publicAssetsStorage
     if (isExternalMediaEnabled) {
@@ -701,57 +711,3 @@ export default defineNuxtModule<ModuleOptions>({
     })
   },
 })
-
-/**
- * Fill in missing repository options from CI environment variables.
- * Supports Vercel, Netlify, GitHub Actions, and GitLab CI.
- */
-function detectRepositoryFromCI(): Partial<GitHubRepositoryOptions | GitLabRepositoryOptions> | undefined {
-  // Vercel
-  if (process.env.VERCEL_GIT_REPO_OWNER && process.env.VERCEL_GIT_REPO_SLUG && ['github', 'gitlab'].includes(process.env.VERCEL_GIT_PROVIDER!)) {
-    return {
-      provider: process.env.VERCEL_GIT_PROVIDER as 'github' | 'gitlab',
-      owner: process.env.VERCEL_GIT_REPO_OWNER,
-      repo: process.env.VERCEL_GIT_REPO_SLUG,
-      branch: process.env.VERCEL_GIT_COMMIT_REF,
-    }
-  }
-
-  // Netlify
-  if (process.env.NETLIFY && process.env.REPOSITORY_URL) {
-    const match = process.env.REPOSITORY_URL.match(/(?:github\.com|gitlab\.com)[:/]([^/]+)\/([^/.]+)/)
-    if (match?.[1] && match[2]) {
-      const isGitLab = process.env.REPOSITORY_URL.includes('gitlab.com')
-      return {
-        provider: isGitLab ? 'gitlab' : 'github',
-        owner: match[1],
-        repo: match[2],
-        branch: process.env.BRANCH,
-      }
-    }
-  }
-
-  // GitHub Actions
-  if (process.env.GITHUB_ACTIONS && process.env.GITHUB_REPOSITORY?.includes('/')) {
-    const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/') as [string, string]
-    return {
-      provider: 'github',
-      owner,
-      repo,
-      branch: process.env.GITHUB_REF_NAME,
-    }
-  }
-
-  // GitLab CI
-  if (process.env.GITLAB_CI && process.env.CI_PROJECT_NAMESPACE && process.env.CI_PROJECT_NAME) {
-    return {
-      provider: 'gitlab',
-      owner: process.env.CI_PROJECT_NAMESPACE,
-      repo: process.env.CI_PROJECT_NAME,
-      branch: process.env.CI_COMMIT_BRANCH,
-      instanceUrl: process.env.CI_SERVER_URL,
-    }
-  }
-
-  return undefined
-}

--- a/src/module/src/runtime/server/middleware/studio-env.ts
+++ b/src/module/src/runtime/server/middleware/studio-env.ts
@@ -1,0 +1,122 @@
+import { defineEventHandler } from 'h3'
+import { useRuntimeConfig } from '#imports'
+import { createHash } from 'node:crypto'
+import { defu } from 'defu'
+import { mergeConfig } from '../utils/object'
+import { detectRepositoryFromCI } from '../utils/repository'
+
+// Read env vars once at server startup (module-import scope).
+// useRuntimeConfig() (argless) is deep-frozen; useRuntimeConfig(event) returns
+// a mutable per-request clone. Fill empty slots from legacy STUDIO_* / AI env vars
+// here so NUXT_* overrides and explicit nuxt.config values take precedence.
+const legacyEnvDefaults = {
+  github: {
+    clientId: process.env.STUDIO_GITHUB_CLIENT_ID,
+    clientSecret: process.env.STUDIO_GITHUB_CLIENT_SECRET,
+    redirectUrl: process.env.STUDIO_GITHUB_REDIRECT_URL,
+    moderators: process.env.STUDIO_GITHUB_MODERATORS,
+  },
+  gitlab: {
+    applicationId: process.env.STUDIO_GITLAB_APPLICATION_ID,
+    applicationSecret: process.env.STUDIO_GITLAB_APPLICATION_SECRET,
+    redirectUrl: process.env.STUDIO_GITLAB_REDIRECT_URL,
+    moderators: process.env.STUDIO_GITLAB_MODERATORS,
+  },
+  google: {
+    clientId: process.env.STUDIO_GOOGLE_CLIENT_ID,
+    clientSecret: process.env.STUDIO_GOOGLE_CLIENT_SECRET,
+    redirectUrl: process.env.STUDIO_GOOGLE_REDIRECT_URL,
+    moderators: process.env.STUDIO_GOOGLE_MODERATORS,
+  },
+  sso: {
+    serverUrl: process.env.STUDIO_SSO_URL,
+    clientId: process.env.STUDIO_SSO_CLIENT_ID,
+    clientSecret: process.env.STUDIO_SSO_CLIENT_SECRET,
+    redirectUrl: process.env.STUDIO_SSO_REDIRECT_URL,
+  },
+  git: {
+    githubToken: process.env.STUDIO_GITHUB_TOKEN,
+    gitlabToken: process.env.STUDIO_GITLAB_TOKEN,
+  },
+  ai: {
+    apiKey: process.env.AI_GATEWAY_API_KEY,
+  },
+  s3PublicUrl: process.env.S3_PUBLIC_URL,
+}
+
+// Detect repository from CI / platform env vars once at server startup.
+// VERCEL_GIT_* and Netlify vars are available at runtime; GitHub Actions / GitLab CI
+// vars are typically build-time only — use explicit nuxt.config or NUXT_PUBLIC_STUDIO_REPOSITORY_*
+// for those deployments.
+const ciRepository = detectRepositoryFromCI()
+
+export default defineEventHandler((event) => {
+  const config = useRuntimeConfig(event)
+  if (!config.studio) return
+
+  // Auth credentials
+  if (config.studio.auth?.github) {
+    config.studio.auth.github = mergeConfig(config.studio.auth.github, legacyEnvDefaults.github)
+  }
+  if (config.studio.auth?.gitlab) {
+    config.studio.auth.gitlab = mergeConfig(config.studio.auth.gitlab, legacyEnvDefaults.gitlab)
+  }
+  if (config.studio.auth?.google) {
+    config.studio.auth.google = mergeConfig(config.studio.auth.google, legacyEnvDefaults.google)
+  }
+  if (config.studio.auth?.sso) {
+    config.studio.auth.sso = mergeConfig(config.studio.auth.sso, legacyEnvDefaults.sso)
+  }
+  if (config.studio.git) {
+    config.studio.git = mergeConfig(config.studio.git, legacyEnvDefaults.git)
+  }
+
+  // AI API key — fills empty slot so NUXT_STUDIO_AI_API_KEY / nuxt.config take precedence
+  if (config.studio.ai) {
+    config.studio.ai = mergeConfig(config.studio.ai, legacyEnvDefaults.ai)
+  }
+
+  // Reflect actual runtime AI availability in the public config so the editor UI is accurate
+  if (config.public?.studio?.ai) {
+    config.public.studio.ai.enabled = Boolean(config.studio.ai?.apiKey)
+  }
+
+  // S3 media public URL
+  if (config.public?.studio?.media && legacyEnvDefaults.s3PublicUrl) {
+    config.public.studio.media = mergeConfig(config.public.studio.media, { publicUrl: legacyEnvDefaults.s3PublicUrl })
+  }
+
+  // Repository — CI detection wins for non-provider fields; provider only set if unset.
+  // Mirrors the original build-time precedence, now resolved at runtime.
+  if (ciRepository && config.public?.studio?.repository !== undefined) {
+    const { provider: detectedProvider, ...detectedWithoutProvider } = ciRepository
+    config.public.studio.repository = defu(detectedWithoutProvider, config.public.studio.repository)
+    config.studio.repository = defu(detectedWithoutProvider, config.studio.repository)
+    if (!config.public.studio.repository.provider && detectedProvider) {
+      config.public.studio.repository.provider = detectedProvider
+    }
+    if (!config.studio.repository.provider && detectedProvider) {
+      config.studio.repository.provider = detectedProvider
+    }
+  }
+
+  // Derive session secret from resolved credentials when none is explicitly set
+  if (!config.studio.auth.sessionSecret) {
+    const credValues = [
+      config.studio.auth.github?.clientId,
+      config.studio.auth.github?.clientSecret,
+      config.studio.auth.gitlab?.applicationId,
+      config.studio.auth.gitlab?.applicationSecret,
+      config.studio.auth.google?.clientId,
+      config.studio.auth.google?.clientSecret,
+      config.studio.auth.sso?.serverUrl,
+      config.studio.auth.sso?.clientId,
+      config.studio.auth.sso?.clientSecret,
+      config.studio.git?.githubToken,
+      config.studio.git?.gitlabToken,
+    ]
+    if (credValues.some(Boolean)) {
+      config.studio.auth.sessionSecret = createHash('md5').update(credValues.join('')).digest('hex')
+    }
+  }
+})

--- a/src/module/src/runtime/server/middleware/studio-env.ts
+++ b/src/module/src/runtime/server/middleware/studio-env.ts
@@ -4,17 +4,12 @@ import { createHash } from 'node:crypto'
 import { defu } from 'defu'
 import { detectRepositoryFromCI } from '../utils/repository'
 
-// Detect repository from CI / platform env vars once at server startup.
-// VERCEL_GIT_* and Netlify vars are available at runtime; GitHub Actions / GitLab CI
-// vars are typically build-time only — use explicit nuxt.config or NUXT_PUBLIC_STUDIO_REPOSITORY_*
-// for those deployments.
 const ciRepository = detectRepositoryFromCI()
 
 export default defineEventHandler((event) => {
   const config = useRuntimeConfig(event)
   if (!config.studio) return
 
-  // Backfill from legacy STUDIO_* / AI_GATEWAY_API_KEY for deployments not yet on NUXT_STUDIO_*.
   if (config.studio.ai) {
     config.studio.ai.apiKey = config.studio.ai.apiKey || process.env.AI_GATEWAY_API_KEY || ''
   }
@@ -62,13 +57,10 @@ export default defineEventHandler((event) => {
     config.studio.media.publicUrl = process.env.S3_PUBLIC_URL || ''
   }
 
-  // Reflect actual runtime AI availability in the public config so the editor UI is accurate
   if (config.public?.studio?.ai) {
     config.public.studio.ai.enabled = Boolean(config.studio.ai?.apiKey)
   }
 
-  // Repository — CI detection wins for non-provider fields; provider only set if unset.
-  // Mirrors the original build-time precedence, now resolved at runtime.
   if (ciRepository && config.public?.studio?.repository !== undefined) {
     const { provider: detectedProvider, ...detectedWithoutProvider } = ciRepository
     config.public.studio.repository = defu(detectedWithoutProvider, config.public.studio.repository)
@@ -81,7 +73,6 @@ export default defineEventHandler((event) => {
     }
   }
 
-  // Derive session secret from resolved credentials when none is explicitly set
   if (!config.studio.auth.sessionSecret) {
     const credValues = [
       config.studio.auth.github?.clientId,

--- a/src/module/src/runtime/server/middleware/studio-env.ts
+++ b/src/module/src/runtime/server/middleware/studio-env.ts
@@ -14,54 +14,37 @@ export default defineEventHandler((event) => {
   const config = useRuntimeConfig(event)
   if (!config.studio) return
 
-  // ---------------------------------------------------------------------------
-  // Backwards compatibility: fill empty runtime-config stubs from legacy STUDIO_*
-  // env vars so that deployments that have not yet migrated to NUXT_STUDIO_*
-  // names continue to work unchanged.
-  //
-  // Precedence (highest → lowest):
-  //   1. nuxt.config values  (baked into stubs at build time)
-  //   2. NUXT_STUDIO_* env vars  (filled by Nuxt's own env-override mechanism)
-  //   3. Legacy STUDIO_* / AI_GATEWAY_API_KEY env vars  (filled here)
-  //
-  // Only fills fields whose current value is empty (""), so options 1 and 2 always win.
-  // ---------------------------------------------------------------------------
-
-  // AI
-  if (!config.studio.ai.apiKey) {
-    config.studio.ai.apiKey = process.env.AI_GATEWAY_API_KEY || ''
+  // Backfill from legacy STUDIO_* / AI_GATEWAY_API_KEY for deployments not yet on NUXT_STUDIO_*.
+  if (config.studio.ai) {
+    config.studio.ai.apiKey = config.studio.ai.apiKey || process.env.AI_GATEWAY_API_KEY || ''
   }
 
-  // GitHub OAuth
-  const gh = config.studio.auth.github
-  if (gh) {
-    gh.clientId = gh.clientId || process.env.STUDIO_GITHUB_CLIENT_ID || ''
-    gh.clientSecret = gh.clientSecret || process.env.STUDIO_GITHUB_CLIENT_SECRET || ''
-    gh.instanceUrl = gh.instanceUrl || process.env.STUDIO_GITHUB_INSTANCE_URL || 'https://github.com'
-    gh.moderators = gh.moderators || process.env.STUDIO_GITHUB_MODERATORS || ''
-    gh.redirectUrl = gh.redirectUrl || process.env.STUDIO_GITHUB_REDIRECT_URL || ''
+  const github = config.studio.auth.github
+  if (github) {
+    github.clientId = github.clientId || process.env.STUDIO_GITHUB_CLIENT_ID || ''
+    github.clientSecret = github.clientSecret || process.env.STUDIO_GITHUB_CLIENT_SECRET || ''
+    github.instanceUrl = github.instanceUrl || process.env.STUDIO_GITHUB_INSTANCE_URL || 'https://github.com'
+    github.moderators = github.moderators || process.env.STUDIO_GITHUB_MODERATORS || ''
+    github.redirectUrl = github.redirectUrl || process.env.STUDIO_GITHUB_REDIRECT_URL || ''
   }
 
-  // GitLab OAuth
-  const gl = config.studio.auth.gitlab
-  if (gl) {
-    gl.applicationId = gl.applicationId || process.env.STUDIO_GITLAB_APPLICATION_ID || ''
-    gl.applicationSecret = gl.applicationSecret || process.env.STUDIO_GITLAB_APPLICATION_SECRET || ''
-    gl.instanceUrl = gl.instanceUrl || process.env.STUDIO_GITLAB_INSTANCE_URL || 'https://gitlab.com'
-    gl.moderators = gl.moderators || process.env.STUDIO_GITLAB_MODERATORS || ''
-    gl.redirectUrl = gl.redirectUrl || process.env.STUDIO_GITLAB_REDIRECT_URL || ''
+  const gitlab = config.studio.auth.gitlab
+  if (gitlab) {
+    gitlab.applicationId = gitlab.applicationId || process.env.STUDIO_GITLAB_APPLICATION_ID || ''
+    gitlab.applicationSecret = gitlab.applicationSecret || process.env.STUDIO_GITLAB_APPLICATION_SECRET || ''
+    gitlab.instanceUrl = gitlab.instanceUrl || process.env.STUDIO_GITLAB_INSTANCE_URL || 'https://gitlab.com'
+    gitlab.moderators = gitlab.moderators || process.env.STUDIO_GITLAB_MODERATORS || ''
+    gitlab.redirectUrl = gitlab.redirectUrl || process.env.STUDIO_GITLAB_REDIRECT_URL || ''
   }
 
-  // Google OAuth
-  const gg = config.studio.auth.google
-  if (gg) {
-    gg.clientId = gg.clientId || process.env.STUDIO_GOOGLE_CLIENT_ID || ''
-    gg.clientSecret = gg.clientSecret || process.env.STUDIO_GOOGLE_CLIENT_SECRET || ''
-    gg.moderators = gg.moderators || process.env.STUDIO_GOOGLE_MODERATORS || ''
-    gg.redirectUrl = gg.redirectUrl || process.env.STUDIO_GOOGLE_REDIRECT_URL || ''
+  const google = config.studio.auth.google
+  if (google) {
+    google.clientId = google.clientId || process.env.STUDIO_GOOGLE_CLIENT_ID || ''
+    google.clientSecret = google.clientSecret || process.env.STUDIO_GOOGLE_CLIENT_SECRET || ''
+    google.moderators = google.moderators || process.env.STUDIO_GOOGLE_MODERATORS || ''
+    google.redirectUrl = google.redirectUrl || process.env.STUDIO_GOOGLE_REDIRECT_URL || ''
   }
 
-  // SSO
   const sso = config.studio.auth.sso
   if (sso) {
     sso.serverUrl = sso.serverUrl || process.env.STUDIO_SSO_URL || ''
@@ -70,22 +53,14 @@ export default defineEventHandler((event) => {
     sso.redirectUrl = sso.redirectUrl || process.env.STUDIO_SSO_REDIRECT_URL || ''
   }
 
-  // Git tokens
-  const git = config.studio.git
-  if (git) {
-    git.githubToken = git.githubToken || process.env.STUDIO_GITHUB_TOKEN || ''
-    git.gitlabToken = git.gitlabToken || process.env.STUDIO_GITLAB_TOKEN || ''
+  if (config.studio.git) {
+    config.studio.git.githubToken = config.studio.git.githubToken || process.env.STUDIO_GITHUB_TOKEN || ''
+    config.studio.git.gitlabToken = config.studio.git.gitlabToken || process.env.STUDIO_GITLAB_TOKEN || ''
   }
 
-  // Media public URL
-  const media = config.studio.media
-  if (media && !media.publicUrl) {
-    media.publicUrl = process.env.S3_PUBLIC_URL || ''
+  if (config.studio.media && !config.studio.media.publicUrl) {
+    config.studio.media.publicUrl = process.env.S3_PUBLIC_URL || ''
   }
-
-  // ---------------------------------------------------------------------------
-  // End of legacy env var backfill
-  // ---------------------------------------------------------------------------
 
   // Reflect actual runtime AI availability in the public config so the editor UI is accurate
   if (config.public?.studio?.ai) {

--- a/src/module/src/runtime/server/middleware/studio-env.ts
+++ b/src/module/src/runtime/server/middleware/studio-env.ts
@@ -14,6 +14,79 @@ export default defineEventHandler((event) => {
   const config = useRuntimeConfig(event)
   if (!config.studio) return
 
+  // ---------------------------------------------------------------------------
+  // Backwards compatibility: fill empty runtime-config stubs from legacy STUDIO_*
+  // env vars so that deployments that have not yet migrated to NUXT_STUDIO_*
+  // names continue to work unchanged.
+  //
+  // Precedence (highest → lowest):
+  //   1. nuxt.config values  (baked into stubs at build time)
+  //   2. NUXT_STUDIO_* env vars  (filled by Nuxt's own env-override mechanism)
+  //   3. Legacy STUDIO_* / AI_GATEWAY_API_KEY env vars  (filled here)
+  //
+  // Only fills fields whose current value is empty (""), so options 1 and 2 always win.
+  // ---------------------------------------------------------------------------
+
+  // AI
+  if (!config.studio.ai.apiKey) {
+    config.studio.ai.apiKey = process.env.AI_GATEWAY_API_KEY || ''
+  }
+
+  // GitHub OAuth
+  const gh = config.studio.auth.github
+  if (gh) {
+    gh.clientId = gh.clientId || process.env.STUDIO_GITHUB_CLIENT_ID || ''
+    gh.clientSecret = gh.clientSecret || process.env.STUDIO_GITHUB_CLIENT_SECRET || ''
+    gh.instanceUrl = gh.instanceUrl || process.env.STUDIO_GITHUB_INSTANCE_URL || 'https://github.com'
+    gh.moderators = gh.moderators || process.env.STUDIO_GITHUB_MODERATORS || ''
+    gh.redirectUrl = gh.redirectUrl || process.env.STUDIO_GITHUB_REDIRECT_URL || ''
+  }
+
+  // GitLab OAuth
+  const gl = config.studio.auth.gitlab
+  if (gl) {
+    gl.applicationId = gl.applicationId || process.env.STUDIO_GITLAB_APPLICATION_ID || ''
+    gl.applicationSecret = gl.applicationSecret || process.env.STUDIO_GITLAB_APPLICATION_SECRET || ''
+    gl.instanceUrl = gl.instanceUrl || process.env.STUDIO_GITLAB_INSTANCE_URL || 'https://gitlab.com'
+    gl.moderators = gl.moderators || process.env.STUDIO_GITLAB_MODERATORS || ''
+    gl.redirectUrl = gl.redirectUrl || process.env.STUDIO_GITLAB_REDIRECT_URL || ''
+  }
+
+  // Google OAuth
+  const gg = config.studio.auth.google
+  if (gg) {
+    gg.clientId = gg.clientId || process.env.STUDIO_GOOGLE_CLIENT_ID || ''
+    gg.clientSecret = gg.clientSecret || process.env.STUDIO_GOOGLE_CLIENT_SECRET || ''
+    gg.moderators = gg.moderators || process.env.STUDIO_GOOGLE_MODERATORS || ''
+    gg.redirectUrl = gg.redirectUrl || process.env.STUDIO_GOOGLE_REDIRECT_URL || ''
+  }
+
+  // SSO
+  const sso = config.studio.auth.sso
+  if (sso) {
+    sso.serverUrl = sso.serverUrl || process.env.STUDIO_SSO_URL || ''
+    sso.clientId = sso.clientId || process.env.STUDIO_SSO_CLIENT_ID || ''
+    sso.clientSecret = sso.clientSecret || process.env.STUDIO_SSO_CLIENT_SECRET || ''
+    sso.redirectUrl = sso.redirectUrl || process.env.STUDIO_SSO_REDIRECT_URL || ''
+  }
+
+  // Git tokens
+  const git = config.studio.git
+  if (git) {
+    git.githubToken = git.githubToken || process.env.STUDIO_GITHUB_TOKEN || ''
+    git.gitlabToken = git.gitlabToken || process.env.STUDIO_GITLAB_TOKEN || ''
+  }
+
+  // Media public URL
+  const media = config.studio.media
+  if (media && !media.publicUrl) {
+    media.publicUrl = process.env.S3_PUBLIC_URL || ''
+  }
+
+  // ---------------------------------------------------------------------------
+  // End of legacy env var backfill
+  // ---------------------------------------------------------------------------
+
   // Reflect actual runtime AI availability in the public config so the editor UI is accurate
   if (config.public?.studio?.ai) {
     config.public.studio.ai.enabled = Boolean(config.studio.ai?.apiKey)

--- a/src/module/src/runtime/server/middleware/studio-env.ts
+++ b/src/module/src/runtime/server/middleware/studio-env.ts
@@ -2,47 +2,7 @@ import { defineEventHandler } from 'h3'
 import { useRuntimeConfig } from '#imports'
 import { createHash } from 'node:crypto'
 import { defu } from 'defu'
-import { mergeConfig } from '../utils/object'
 import { detectRepositoryFromCI } from '../utils/repository'
-
-// Read env vars once at server startup (module-import scope).
-// useRuntimeConfig() (argless) is deep-frozen; useRuntimeConfig(event) returns
-// a mutable per-request clone. Fill empty slots from legacy STUDIO_* / AI env vars
-// here so NUXT_* overrides and explicit nuxt.config values take precedence.
-const legacyEnvDefaults = {
-  github: {
-    clientId: process.env.STUDIO_GITHUB_CLIENT_ID,
-    clientSecret: process.env.STUDIO_GITHUB_CLIENT_SECRET,
-    redirectUrl: process.env.STUDIO_GITHUB_REDIRECT_URL,
-    moderators: process.env.STUDIO_GITHUB_MODERATORS,
-  },
-  gitlab: {
-    applicationId: process.env.STUDIO_GITLAB_APPLICATION_ID,
-    applicationSecret: process.env.STUDIO_GITLAB_APPLICATION_SECRET,
-    redirectUrl: process.env.STUDIO_GITLAB_REDIRECT_URL,
-    moderators: process.env.STUDIO_GITLAB_MODERATORS,
-  },
-  google: {
-    clientId: process.env.STUDIO_GOOGLE_CLIENT_ID,
-    clientSecret: process.env.STUDIO_GOOGLE_CLIENT_SECRET,
-    redirectUrl: process.env.STUDIO_GOOGLE_REDIRECT_URL,
-    moderators: process.env.STUDIO_GOOGLE_MODERATORS,
-  },
-  sso: {
-    serverUrl: process.env.STUDIO_SSO_URL,
-    clientId: process.env.STUDIO_SSO_CLIENT_ID,
-    clientSecret: process.env.STUDIO_SSO_CLIENT_SECRET,
-    redirectUrl: process.env.STUDIO_SSO_REDIRECT_URL,
-  },
-  git: {
-    githubToken: process.env.STUDIO_GITHUB_TOKEN,
-    gitlabToken: process.env.STUDIO_GITLAB_TOKEN,
-  },
-  ai: {
-    apiKey: process.env.AI_GATEWAY_API_KEY,
-  },
-  s3PublicUrl: process.env.S3_PUBLIC_URL,
-}
 
 // Detect repository from CI / platform env vars once at server startup.
 // VERCEL_GIT_* and Netlify vars are available at runtime; GitHub Actions / GitLab CI
@@ -54,36 +14,9 @@ export default defineEventHandler((event) => {
   const config = useRuntimeConfig(event)
   if (!config.studio) return
 
-  // Auth credentials
-  if (config.studio.auth?.github) {
-    config.studio.auth.github = mergeConfig(config.studio.auth.github, legacyEnvDefaults.github)
-  }
-  if (config.studio.auth?.gitlab) {
-    config.studio.auth.gitlab = mergeConfig(config.studio.auth.gitlab, legacyEnvDefaults.gitlab)
-  }
-  if (config.studio.auth?.google) {
-    config.studio.auth.google = mergeConfig(config.studio.auth.google, legacyEnvDefaults.google)
-  }
-  if (config.studio.auth?.sso) {
-    config.studio.auth.sso = mergeConfig(config.studio.auth.sso, legacyEnvDefaults.sso)
-  }
-  if (config.studio.git) {
-    config.studio.git = mergeConfig(config.studio.git, legacyEnvDefaults.git)
-  }
-
-  // AI API key — fills empty slot so NUXT_STUDIO_AI_API_KEY / nuxt.config take precedence
-  if (config.studio.ai) {
-    config.studio.ai = mergeConfig(config.studio.ai, legacyEnvDefaults.ai)
-  }
-
   // Reflect actual runtime AI availability in the public config so the editor UI is accurate
   if (config.public?.studio?.ai) {
     config.public.studio.ai.enabled = Boolean(config.studio.ai?.apiKey)
-  }
-
-  // S3 media public URL
-  if (config.public?.studio?.media && legacyEnvDefaults.s3PublicUrl) {
-    config.public.studio.media = mergeConfig(config.public.studio.media, { publicUrl: legacyEnvDefaults.s3PublicUrl })
   }
 
   // Repository — CI detection wins for non-provider fields; provider only set if unset.

--- a/src/module/src/runtime/server/routes/admin.ts
+++ b/src/module/src/runtime/server/routes/admin.ts
@@ -12,7 +12,7 @@ export default eventHandler((event) => {
     })
   }
 
-  // Detect providers from runtimeConfig (populated at build time from env vars).
+  // Detect providers from runtimeConfig (populated at request time by the studio-env middleware).
   const { studio } = useRuntimeConfig(event)
   const auth = studio?.auth
   const hasGithub = auth?.github?.clientId && 'github'

--- a/src/module/src/runtime/server/routes/admin.ts
+++ b/src/module/src/runtime/server/routes/admin.ts
@@ -12,7 +12,6 @@ export default eventHandler((event) => {
     })
   }
 
-  // Detect providers from runtimeConfig (populated at request time by the studio-env middleware).
   const { studio } = useRuntimeConfig(event)
   const auth = studio?.auth
   const hasGithub = auth?.github?.clientId && 'github'

--- a/src/module/src/runtime/server/routes/ai/analyze.post.ts
+++ b/src/module/src/runtime/server/routes/ai/analyze.post.ts
@@ -53,7 +53,7 @@ export default eventHandler(async (event) => {
   if (!apiKey) {
     throw createError({
       statusCode: 503,
-      statusMessage: 'AI features are not enabled. Please set AI_GATEWAY_API_KEY environment variable.',
+      statusMessage: 'AI features are not enabled. Please set NUXT_STUDIO_AI_API_KEY environment variable.',
     })
   }
 

--- a/src/module/src/runtime/server/routes/ai/generate.post.ts
+++ b/src/module/src/runtime/server/routes/ai/generate.post.ts
@@ -20,7 +20,7 @@ export default eventHandler(async (event) => {
   if (!apiKey) {
     throw createError({
       statusCode: 503,
-      statusMessage: 'AI features are not enabled. Please set AI_GATEWAY_API_KEY environment variable.',
+      statusMessage: 'AI features are not enabled. Please set NUXT_STUDIO_AI_API_KEY environment variable.',
     })
   }
 

--- a/src/module/src/runtime/server/routes/auth/github.get.ts
+++ b/src/module/src/runtime/server/routes/auth/github.get.ts
@@ -10,14 +10,19 @@ import { mergeConfig } from '../../utils/object'
 export interface OAuthGitHubConfig {
   /**
    * GitHub OAuth Client ID
-   * @default process.env.STUDIO_GITHUB_CLIENT_ID
+   * @default NUXT_STUDIO_AUTH_GITHUB_CLIENT_ID
    */
   clientId?: string
   /**
    * GitHub OAuth Client Secret
-   * @default process.env.STUDIO_GITHUB_CLIENT_SECRET
+   * @default NUXT_STUDIO_AUTH_GITHUB_CLIENT_SECRET
    */
   clientSecret?: string
+  /**
+   * Comma-separated list of allowed email addresses.
+   * @default NUXT_STUDIO_AUTH_GITHUB_MODERATORS
+   */
+  moderators?: string
   /**
    * GitHub OAuth Scope
    * @default []
@@ -65,8 +70,8 @@ export interface OAuthGitHubConfig {
   authorizationParams?: Record<string, string>
 
   /**
-   * Redirect URL to to allow overriding for situations like prod failing to determine public hostname
-   * Use `process.env.STUDIO_GITHUB_REDIRECT_URL` to overwrite the default redirect URL.
+   * Redirect URL to allow overriding for situations like prod failing to determine public hostname
+   * Set via NUXT_STUDIO_AUTH_GITHUB_REDIRECT_URL environment variable.
    * @default is ${hostname}/__nuxt_studio/auth/github
    */
   redirectURL?: string
@@ -80,7 +85,6 @@ export default eventHandler(async (event: H3Event) => {
   const instanceUrl = withoutTrailingSlash(studioConfig?.auth?.github?.instanceUrl || studioConfig?.repository?.instanceUrl || 'https://github.com')
   const isEnterprise = new URL(instanceUrl).hostname !== 'github.com'
   const config = mergeConfig<OAuthGitHubConfig>(studioConfig?.auth?.github, {
-    redirectURL: studioConfig?.auth?.github?.redirectUrl,
     instanceUrl,
     authorizationURL: `${instanceUrl}/login/oauth/authorize`,
     tokenURL: `${instanceUrl}/login/oauth/access_token`,
@@ -196,7 +200,7 @@ export default eventHandler(async (event: H3Event) => {
     user.email = primaryEmail.email
   }
 
-  const moderators = studioConfig?.auth?.github?.moderators?.split(',').filter(Boolean) || []
+  const moderators = studioConfig?.auth?.github?.moderators?.split(',') || []
   if (moderators.length > 0 && !moderators.includes(String(user.email))) {
     throw createError({
       statusCode: 403,

--- a/src/module/src/runtime/server/routes/auth/github.get.ts
+++ b/src/module/src/runtime/server/routes/auth/github.get.ts
@@ -80,9 +80,7 @@ export default eventHandler(async (event: H3Event) => {
   const instanceUrl = withoutTrailingSlash(studioConfig?.auth?.github?.instanceUrl || studioConfig?.repository?.instanceUrl || 'https://github.com')
   const isEnterprise = new URL(instanceUrl).hostname !== 'github.com'
   const config = mergeConfig<OAuthGitHubConfig>(studioConfig?.auth?.github, {
-    clientId: process.env.STUDIO_GITHUB_CLIENT_ID,
-    clientSecret: process.env.STUDIO_GITHUB_CLIENT_SECRET,
-    redirectURL: process.env.STUDIO_GITHUB_REDIRECT_URL,
+    redirectURL: studioConfig?.auth?.github?.redirectUrl,
     instanceUrl,
     authorizationURL: `${instanceUrl}/login/oauth/authorize`,
     tokenURL: `${instanceUrl}/login/oauth/access_token`,
@@ -198,7 +196,7 @@ export default eventHandler(async (event: H3Event) => {
     user.email = primaryEmail.email
   }
 
-  const moderators = process.env.STUDIO_GITHUB_MODERATORS?.split(',') || []
+  const moderators = studioConfig?.auth?.github?.moderators?.split(',').filter(Boolean) || []
   if (moderators.length > 0 && !moderators.includes(String(user.email))) {
     throw createError({
       statusCode: 403,

--- a/src/module/src/runtime/server/routes/auth/gitlab.get.ts
+++ b/src/module/src/runtime/server/routes/auth/gitlab.get.ts
@@ -91,9 +91,7 @@ export default eventHandler(async (event: H3Event) => {
   const instanceUrl = withoutTrailingSlash(studioConfig?.auth?.gitlab?.instanceUrl || studioConfig?.repository?.instanceUrl || 'https://gitlab.com')
 
   const config = mergeConfig<OAuthGitLabConfig>(studioConfig?.auth?.gitlab, {
-    applicationId: process.env.STUDIO_GITLAB_APPLICATION_ID,
-    applicationSecret: process.env.STUDIO_GITLAB_APPLICATION_SECRET,
-    redirectURL: process.env.STUDIO_GITLAB_REDIRECT_URL,
+    redirectURL: studioConfig?.auth?.gitlab?.redirectUrl,
     instanceUrl,
     authorizationURL: `${instanceUrl}/oauth/authorize`,
     tokenURL: `${instanceUrl}/oauth/token`,
@@ -194,7 +192,7 @@ export default eventHandler(async (event: H3Event) => {
     })
   }
 
-  const moderators = process.env.STUDIO_GITLAB_MODERATORS?.split(',') || []
+  const moderators = studioConfig?.auth?.gitlab?.moderators?.split(',').filter(Boolean) || []
   if (moderators.length > 0 && !moderators.includes(String(user.email))) {
     throw createError({
       statusCode: 403,

--- a/src/module/src/runtime/server/routes/auth/gitlab.get.ts
+++ b/src/module/src/runtime/server/routes/auth/gitlab.get.ts
@@ -11,14 +11,19 @@ import { mergeConfig } from '../../utils/object'
 export interface OAuthGitLabConfig {
   /**
    * GitLab OAuth Application ID
-   * @default process.env.STUDIO_GITLAB_APPLICATION_ID
+   * @default NUXT_STUDIO_AUTH_GITLAB_APPLICATION_ID
    */
   applicationId?: string
   /**
    * GitLab OAuth Application Secret
-   * @default process.env.STUDIO_GITLAB_APPLICATION_SECRET
+   * @default NUXT_STUDIO_AUTH_GITLAB_APPLICATION_SECRET
    */
   applicationSecret?: string
+  /**
+   * Comma-separated list of allowed email addresses.
+   * @default NUXT_STUDIO_AUTH_GITLAB_MODERATORS
+   */
+  moderators?: string
   /**
    * GitLab OAuth Scope
    * @default []
@@ -62,7 +67,7 @@ export interface OAuthGitLabConfig {
 
   /**
    * Redirect URL to allow overriding for situations like prod failing to determine public hostname
-   * Use `process.env.STUDIO_GITLAB_REDIRECT_URL` to overwrite the default redirect URL.
+   * Set via NUXT_STUDIO_AUTH_GITLAB_REDIRECT_URL environment variable.
    * @default is ${hostname}/__nuxt_studio/auth/gitlab
    */
   redirectURL?: string
@@ -91,7 +96,6 @@ export default eventHandler(async (event: H3Event) => {
   const instanceUrl = withoutTrailingSlash(studioConfig?.auth?.gitlab?.instanceUrl || studioConfig?.repository?.instanceUrl || 'https://gitlab.com')
 
   const config = mergeConfig<OAuthGitLabConfig>(studioConfig?.auth?.gitlab, {
-    redirectURL: studioConfig?.auth?.gitlab?.redirectUrl,
     instanceUrl,
     authorizationURL: `${instanceUrl}/oauth/authorize`,
     tokenURL: `${instanceUrl}/oauth/token`,
@@ -192,7 +196,7 @@ export default eventHandler(async (event: H3Event) => {
     })
   }
 
-  const moderators = studioConfig?.auth?.gitlab?.moderators?.split(',').filter(Boolean) || []
+  const moderators = studioConfig?.auth?.gitlab?.moderators?.split(',') || []
   if (moderators.length > 0 && !moderators.includes(String(user.email))) {
     throw createError({
       statusCode: 403,

--- a/src/module/src/runtime/server/routes/auth/google.get.ts
+++ b/src/module/src/runtime/server/routes/auth/google.get.ts
@@ -79,9 +79,7 @@ export default eventHandler(async (event: H3Event) => {
    */
   const studioConfig = useRuntimeConfig(event).studio
   const config = mergeConfig<OAuthGoogleConfig>(studioConfig?.auth?.google, {
-    clientId: process.env.STUDIO_GOOGLE_CLIENT_ID,
-    clientSecret: process.env.STUDIO_GOOGLE_CLIENT_SECRET,
-    redirectURL: process.env.STUDIO_GOOGLE_REDIRECT_URL,
+    redirectURL: studioConfig?.auth?.google?.redirectUrl,
     authorizationURL: 'https://accounts.google.com/o/oauth2/v2/auth',
     tokenURL: 'https://oauth2.googleapis.com/token',
     userURL: 'https://www.googleapis.com/oauth2/v3/userinfo',
@@ -137,22 +135,22 @@ export default eventHandler(async (event: H3Event) => {
    * Git provider token validation
    */
   const provider = studioConfig?.repository.provider
-  if (provider === 'github' && !process.env.STUDIO_GITHUB_TOKEN) {
+  const repositoryToken = provider === 'github'
+    ? studioConfig?.git?.githubToken
+    : studioConfig?.git?.gitlabToken
+
+  if (provider === 'github' && !repositoryToken) {
     throw createError({
       statusCode: 500,
       message: '`STUDIO_GITHUB_TOKEN` is not set. Google authenticated users cannot push changes to the repository without a valid GitHub token.',
     })
   }
-  if (provider === 'gitlab' && !process.env.STUDIO_GITLAB_TOKEN) {
+  if (provider === 'gitlab' && !repositoryToken) {
     throw createError({
       statusCode: 500,
       message: '`STUDIO_GITLAB_TOKEN` is not set. Google authenticated users cannot push changes to the repository without a valid GitLab token.',
     })
   }
-
-  const repositoryToken = provider === 'github'
-    ? process.env.STUDIO_GITHUB_TOKEN
-    : process.env.STUDIO_GITLAB_TOKEN
 
   const token = await requestAccessToken(config.tokenURL as string, {
     body: {
@@ -191,7 +189,7 @@ export default eventHandler(async (event: H3Event) => {
     })
   }
 
-  const moderators = process.env.STUDIO_GOOGLE_MODERATORS?.split(',') || []
+  const moderators = studioConfig?.auth?.google?.moderators?.split(',').filter(Boolean) || []
 
   if (!moderators.includes(user.email)) {
     if (import.meta.dev && moderators.length === 0) {

--- a/src/module/src/runtime/server/routes/auth/google.get.ts
+++ b/src/module/src/runtime/server/routes/auth/google.get.ts
@@ -20,12 +20,12 @@ export interface GoogleUser {
 export interface OAuthGoogleConfig {
   /**
    * Google OAuth Client ID
-   * @default process.env.STUDIO_GOOGLE_CLIENT_ID
+   * @default NUXT_STUDIO_AUTH_GOOGLE_CLIENT_ID
    */
   clientId?: string
   /**
    * Google OAuth Client Secret
-   * @default process.env.STUDIO_GOOGLE_CLIENT_SECRET
+   * @default NUXT_STUDIO_AUTH_GOOGLE_CLIENT_SECRET
    */
   clientSecret?: string
   /**
@@ -66,8 +66,8 @@ export interface OAuthGoogleConfig {
   authorizationParams?: Record<string, string>
 
   /**
-   * Redirect URL to to allow overriding for situations like prod failing to determine public hostname
-   * Use `process.env.STUDIO_GOOGLE_REDIRECT_URL` to overwrite the default redirect URL.
+   * Redirect URL to allow overriding for situations like prod failing to determine public hostname
+   * Set via NUXT_STUDIO_AUTH_GOOGLE_REDIRECT_URL environment variable.
    * @default is ${hostname}/__nuxt_studio/auth/google
    */
   redirectURL?: string
@@ -79,7 +79,6 @@ export default eventHandler(async (event: H3Event) => {
    */
   const studioConfig = useRuntimeConfig(event).studio
   const config = mergeConfig<OAuthGoogleConfig>(studioConfig?.auth?.google, {
-    redirectURL: studioConfig?.auth?.google?.redirectUrl,
     authorizationURL: 'https://accounts.google.com/o/oauth2/v2/auth',
     tokenURL: 'https://oauth2.googleapis.com/token',
     userURL: 'https://www.googleapis.com/oauth2/v3/userinfo',
@@ -138,17 +137,16 @@ export default eventHandler(async (event: H3Event) => {
   const repositoryToken = provider === 'github'
     ? studioConfig?.git?.githubToken
     : studioConfig?.git?.gitlabToken
-
   if (provider === 'github' && !repositoryToken) {
     throw createError({
       statusCode: 500,
-      message: '`STUDIO_GITHUB_TOKEN` is not set. Google authenticated users cannot push changes to the repository without a valid GitHub token.',
+      message: '`NUXT_STUDIO_GIT_GITHUB_TOKEN` is not set. Google authenticated users cannot push changes to the repository without a valid GitHub token.',
     })
   }
   if (provider === 'gitlab' && !repositoryToken) {
     throw createError({
       statusCode: 500,
-      message: '`STUDIO_GITLAB_TOKEN` is not set. Google authenticated users cannot push changes to the repository without a valid GitLab token.',
+      message: '`NUXT_STUDIO_GIT_GITLAB_TOKEN` is not set. Google authenticated users cannot push changes to the repository without a valid GitLab token.',
     })
   }
 
@@ -189,13 +187,13 @@ export default eventHandler(async (event: H3Event) => {
     })
   }
 
-  const moderators = studioConfig?.auth?.google?.moderators?.split(',').filter(Boolean) || []
+  const moderators = studioConfig?.auth?.google?.moderators?.split(',') || []
 
   if (!moderators.includes(user.email)) {
     if (import.meta.dev && moderators.length === 0) {
       logger.warn([
         'No moderators defined. Moderators are required for Google authentication.',
-        'Please set the `STUDIO_GOOGLE_MODERATORS` environment variable to a comma-separated list of email addresses of the moderators.',
+        'Please set the `NUXT_STUDIO_AUTH_GOOGLE_MODERATORS` environment variable to a comma-separated list of email addresses of the moderators.',
       ].join('\n'))
     }
 

--- a/src/module/src/runtime/server/routes/auth/sso.get.ts
+++ b/src/module/src/runtime/server/routes/auth/sso.get.ts
@@ -3,6 +3,7 @@ import { createError, deleteCookie, eventHandler, getCookie, getQuery, getReques
 import { withQuery } from 'ufo'
 import { consumePKCECodeVerifier, generateCodeChallenge, generateOAuthState, generatePKCECodeVerifier, requestAccessToken, validateOAuthState } from '../../utils/auth'
 import { setInternalStudioUserSession } from '../../utils/session'
+import { mergeConfig } from '../../utils/object'
 
 export interface SSOUser {
   sub: string
@@ -16,17 +17,17 @@ export interface SSOUser {
 export interface SSOServerConfig {
   /**
    * SSO Server URL (e.g., 'https://auth.example.com')
-   * @default process.env.STUDIO_SSO_URL
+   * @default NUXT_STUDIO_AUTH_SSO_SERVER_URL
    */
   serverUrl?: string
   /**
    * SSO Client ID
-   * @default process.env.STUDIO_SSO_CLIENT_ID
+   * @default NUXT_STUDIO_AUTH_SSO_CLIENT_ID
    */
   clientId?: string
   /**
    * SSO Client Secret
-   * @default process.env.STUDIO_SSO_CLIENT_SECRET
+   * @default NUXT_STUDIO_AUTH_SSO_CLIENT_SECRET
    */
   clientSecret?: string
   /**
@@ -41,11 +42,7 @@ export default eventHandler(async (event: H3Event) => {
    * SSO provider validation
    */
   const studioConfig = useRuntimeConfig(event).studio
-  const sso = studioConfig?.auth?.sso
-  const config: SSOServerConfig = {
-    ...sso,
-    redirectURL: sso?.redirectUrl,
-  }
+  const config = mergeConfig<SSOServerConfig>(studioConfig?.auth?.sso, {})
 
   const query = getQuery<{ code?: string, error?: string, error_description?: string, state?: string }>(event)
 
@@ -60,7 +57,7 @@ export default eventHandler(async (event: H3Event) => {
   if (!config.serverUrl || !config.clientId || !config.clientSecret) {
     throw createError({
       statusCode: 500,
-      message: 'Missing SSO server URL, client ID, or client secret. Set STUDIO_SSO_URL, STUDIO_SSO_CLIENT_ID, and STUDIO_SSO_CLIENT_SECRET environment variables.',
+      message: 'Missing SSO server URL, client ID, or client secret. Set NUXT_STUDIO_AUTH_SSO_SERVER_URL, NUXT_STUDIO_AUTH_SSO_CLIENT_ID, and NUXT_STUDIO_AUTH_SSO_CLIENT_SECRET.',
       data: config,
     })
   }
@@ -151,7 +148,7 @@ export default eventHandler(async (event: H3Event) => {
   if (provider === 'github' && user.github_token) {
     repositoryToken = user.github_token
   }
-  // Fall back to environment variable
+  // Fall back to configured git token
   else if (provider === 'github') {
     repositoryToken = studioConfig?.git?.githubToken
   }
@@ -169,7 +166,7 @@ export default eventHandler(async (event: H3Event) => {
   if (provider === 'gitlab' && !repositoryToken) {
     throw createError({
       statusCode: 500,
-      message: '`STUDIO_GITLAB_TOKEN` is not set. SSO authenticated users cannot push changes to the repository without a valid GitLab token.',
+      message: '`NUXT_STUDIO_GIT_GITLAB_TOKEN` is not set. SSO authenticated users cannot push changes to the repository without a valid GitLab token.',
     })
   }
 

--- a/src/module/src/runtime/server/routes/auth/sso.get.ts
+++ b/src/module/src/runtime/server/routes/auth/sso.get.ts
@@ -3,7 +3,6 @@ import { createError, deleteCookie, eventHandler, getCookie, getQuery, getReques
 import { withQuery } from 'ufo'
 import { consumePKCECodeVerifier, generateCodeChallenge, generateOAuthState, generatePKCECodeVerifier, requestAccessToken, validateOAuthState } from '../../utils/auth'
 import { setInternalStudioUserSession } from '../../utils/session'
-import { mergeConfig } from '../../utils/object'
 
 export interface SSOUser {
   sub: string
@@ -42,12 +41,11 @@ export default eventHandler(async (event: H3Event) => {
    * SSO provider validation
    */
   const studioConfig = useRuntimeConfig(event).studio
-  const config = mergeConfig<SSOServerConfig>(studioConfig?.auth?.sso, {
-    serverUrl: process.env.STUDIO_SSO_URL,
-    clientId: process.env.STUDIO_SSO_CLIENT_ID,
-    clientSecret: process.env.STUDIO_SSO_CLIENT_SECRET,
-    redirectURL: process.env.STUDIO_SSO_REDIRECT_URL,
-  })
+  const sso = studioConfig?.auth?.sso
+  const config: SSOServerConfig = {
+    ...sso,
+    redirectURL: sso?.redirectUrl,
+  }
 
   const query = getQuery<{ code?: string, error?: string, error_description?: string, state?: string }>(event)
 
@@ -155,10 +153,10 @@ export default eventHandler(async (event: H3Event) => {
   }
   // Fall back to environment variable
   else if (provider === 'github') {
-    repositoryToken = process.env.STUDIO_GITHUB_TOKEN
+    repositoryToken = studioConfig?.git?.githubToken
   }
   else if (provider === 'gitlab') {
-    repositoryToken = process.env.STUDIO_GITLAB_TOKEN
+    repositoryToken = studioConfig?.git?.gitlabToken
   }
 
   // Validate that we have a token

--- a/src/module/src/runtime/server/utils/media/ipx.ts
+++ b/src/module/src/runtime/server/utils/media/ipx.ts
@@ -10,7 +10,8 @@ export const DAY_IN_SECONDS = 60 * 60 * 24
 
 const mediaConfig = useRuntimeConfig().public.studio.media
 const studioConfig = useRuntimeConfig().public.studio
-export const publicDir: string = mediaConfig.publicUrl
+const resolvedPublicUrl = mediaConfig.publicUrl || process.env.S3_PUBLIC_URL || ''
+export const publicDir: string = resolvedPublicUrl
 
 // ipx is an optional dependency (requires sharp which uses native binaries
 // unavailable on some platforms such as Cloudflare Workers). The import is
@@ -78,7 +79,7 @@ async function loadIpxModule() {
 
 export function requireAllowedDomain(id: string): string | undefined {
   if (!mediaConfig.external) return undefined
-  const configuredDomain = parseURL(mediaConfig.publicUrl).host
+  const configuredDomain = parseURL(resolvedPublicUrl).host
   const requestDomain = parseURL(id).host
   if (configuredDomain && requestDomain !== configuredDomain) {
     throw createError({ statusCode: 403, statusMessage: 'IPX_FORBIDDEN_DOMAIN' })

--- a/src/module/src/runtime/server/utils/media/ipx.ts
+++ b/src/module/src/runtime/server/utils/media/ipx.ts
@@ -10,7 +10,7 @@ export const DAY_IN_SECONDS = 60 * 60 * 24
 
 const mediaConfig = useRuntimeConfig().public.studio.media
 const studioConfig = useRuntimeConfig().public.studio
-const resolvedPublicUrl = mediaConfig.publicUrl || process.env.S3_PUBLIC_URL || ''
+const resolvedPublicUrl = mediaConfig.publicUrl || ''
 export const publicDir: string = resolvedPublicUrl
 
 // ipx is an optional dependency (requires sharp which uses native binaries

--- a/src/module/src/runtime/server/utils/repository.ts
+++ b/src/module/src/runtime/server/utils/repository.ts
@@ -1,0 +1,67 @@
+/**
+ * Detect repository information from CI / platform environment variables at runtime.
+ * Supports Vercel, Netlify, GitHub Actions, and GitLab CI.
+ *
+ * Note: VERCEL_GIT_* and Netlify REPOSITORY_URL / BRANCH env vars are present in the
+ * running server process, so they resolve at runtime.  GITHUB_ACTIONS and GITLAB_CI env
+ * vars are typically only available during the CI build pipeline; for deployments that rely
+ * on those, set explicit `repository` config in nuxt.config.ts or via
+ * NUXT_PUBLIC_STUDIO_REPOSITORY_* environment variables instead.
+ */
+export interface RepositoryDetection {
+  provider?: 'github' | 'gitlab'
+  owner?: string
+  repo?: string
+  branch?: string
+  instanceUrl?: string
+}
+
+export function detectRepositoryFromCI(): RepositoryDetection | undefined {
+  // Vercel (available at runtime)
+  if (process.env.VERCEL_GIT_REPO_OWNER && process.env.VERCEL_GIT_REPO_SLUG && ['github', 'gitlab'].includes(process.env.VERCEL_GIT_PROVIDER!)) {
+    return {
+      provider: process.env.VERCEL_GIT_PROVIDER as 'github' | 'gitlab',
+      owner: process.env.VERCEL_GIT_REPO_OWNER,
+      repo: process.env.VERCEL_GIT_REPO_SLUG,
+      branch: process.env.VERCEL_GIT_COMMIT_REF,
+    }
+  }
+
+  // Netlify (available at runtime)
+  if (process.env.NETLIFY && process.env.REPOSITORY_URL) {
+    const match = process.env.REPOSITORY_URL.match(/(?:github\.com|gitlab\.com)[:/]([^/]+)\/([^/.]+)/)
+    if (match?.[1] && match[2]) {
+      const isGitLab = process.env.REPOSITORY_URL.includes('gitlab.com')
+      return {
+        provider: isGitLab ? 'gitlab' : 'github',
+        owner: match[1],
+        repo: match[2],
+        branch: process.env.BRANCH,
+      }
+    }
+  }
+
+  // GitHub Actions (build-time only in most CI setups)
+  if (process.env.GITHUB_ACTIONS && process.env.GITHUB_REPOSITORY?.includes('/')) {
+    const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/') as [string, string]
+    return {
+      provider: 'github',
+      owner,
+      repo,
+      branch: process.env.GITHUB_REF_NAME,
+    }
+  }
+
+  // GitLab CI (build-time only in most CI setups)
+  if (process.env.GITLAB_CI && process.env.CI_PROJECT_NAMESPACE && process.env.CI_PROJECT_NAME) {
+    return {
+      provider: 'gitlab',
+      owner: process.env.CI_PROJECT_NAMESPACE,
+      repo: process.env.CI_PROJECT_NAME,
+      branch: process.env.CI_COMMIT_BRANCH,
+      instanceUrl: process.env.CI_SERVER_URL,
+    }
+  }
+
+  return undefined
+}

--- a/src/module/src/runtime/server/utils/session.ts
+++ b/src/module/src/runtime/server/utils/session.ts
@@ -17,11 +17,12 @@ const requiredUserFields: Array<keyof StudioUser> = ['name', 'email']
 export async function setStudioUserSession(event: H3Event, userSession: StudioUserSession) {
   const config = useRuntimeConfig().public
   const provider = config.studio.repository.provider as GitProviderType
+  const studioConfig = useRuntimeConfig(event).studio
   const accessToken
     = provider === 'github'
-      ? process.env.STUDIO_GITHUB_TOKEN
+      ? studioConfig?.git?.githubToken
       : provider === 'gitlab'
-        ? process.env.STUDIO_GITLAB_TOKEN
+        ? studioConfig?.git?.gitlabToken
         : null
 
   if (!accessToken) {

--- a/src/module/src/runtime/server/utils/session.ts
+++ b/src/module/src/runtime/server/utils/session.ts
@@ -15,14 +15,13 @@ interface StudioUserSession {
 const requiredUserFields: Array<keyof StudioUser> = ['name', 'email']
 
 export async function setStudioUserSession(event: H3Event, userSession: StudioUserSession) {
-  const config = useRuntimeConfig().public
-  const provider = config.studio.repository.provider as GitProviderType
-  const studioConfig = useRuntimeConfig(event).studio
+  const config = useRuntimeConfig(event)
+  const provider = config.public.studio.repository.provider as GitProviderType
   const accessToken
     = provider === 'github'
-      ? studioConfig?.git?.githubToken
+      ? config.studio?.git?.githubToken
       : provider === 'gitlab'
-        ? studioConfig?.git?.gitlabToken
+        ? config.studio?.git?.gitlabToken
         : null
 
   if (!accessToken) {


### PR DESCRIPTION
## What and why

Previously, all secret env vars (`STUDIO_GITHUB_CLIENT_SECRET`, `AI_GATEWAY_API_KEY`, git tokens, etc.) were read from `process.env` during `nuxt build` and baked into the server bundle. This causes two problems:

- **Security** - any CI environment that has secrets available at build time ends up with those values as plaintext literals in the `.output/server/` artifact. Build artifacts are often cached, stored, or shared in ways that runtime environments aren't.
- **DX** - because the AI feature flag was evaluated at build time (`if (options.ai?.apiKey)`), deploying a generic image without `AI_GATEWAY_API_KEY` set at build time permanently disables AI, even if the var is present at runtime. Same applies to auth providers.

## Approach

A server middleware (`studio-env.ts`) registered via `addServerHandler({ middleware: true })` runs on every request and merges `STUDIO_*` env vars into `useRuntimeConfig(event).studio.*` for any values that aren't already set. Using the per-request config (with an event) is required because the argless `useRuntimeConfig()` returns a deep-frozen shared singleton — only the per-request clone is mutable. All auth routes and session utils already read from `useRuntimeConfig(event).studio.*` and need no changes.

The `runtimeConfig.studio` schema in `module.ts` is initialised with empty string stubs so Nuxt knows the shape at build time. The middleware fills in real values at request time using `mergeConfig` (the empty-string-aware `defu` variant) so Nuxt-native `NUXT_STUDIO_*` env vars and explicit `nuxt.config` values always take precedence over the legacy names.

## Backward compatibility

All existing env vars should continue to work unchanged.

Resolves https://github.com/nuxt-content/nuxt-studio/issues/139