### PR TITLE
fix(compare): apply cleanDataKeys normalization before conflict comparison

### DIFF
--- a/src/module/src/runtime/utils/document/compare.ts
+++ b/src/module/src/runtime/utils/document/compare.ts
@@ -31,8 +31,8 @@ export async function isDocumentMatchingContent(content: string, document: Datab
   const generatedDocument = await documentFromContent(document.id, content, { compress: true, preserveLinkAttributes: true }) as DatabaseItem
 
   if (generatedDocument.extension === ContentFileExtension.Markdown) {
-    const { body: generatedBody, ...generatedDocumentData } = generatedDocument
-    const { body: documentBody, ...documentData } = document
+    const { body: generatedBody } = generatedDocument
+    const { body: documentBody } = document
 
     // Compare body nodes only (not frontmatter — that's compared separately via doObjectsMatch below).
     const generatedNormalized = normalizeAttrsDeep({ ...(generatedBody as ComarkTree), frontmatter: {} })

--- a/src/module/src/runtime/utils/document/compare.ts
+++ b/src/module/src/runtime/utils/document/compare.ts
@@ -31,12 +31,9 @@ export async function isDocumentMatchingContent(content: string, document: Datab
   const generatedDocument = await documentFromContent(document.id, content, { compress: true, preserveLinkAttributes: true }) as DatabaseItem
 
   if (generatedDocument.extension === ContentFileExtension.Markdown) {
-    const { body: generatedBody } = generatedDocument
-    const { body: documentBody } = document
-
     // Compare body nodes only (not frontmatter — that's compared separately via doObjectsMatch below).
-    const generatedNormalized = normalizeAttrsDeep({ ...(generatedBody as ComarkTree), frontmatter: {} })
-    const documentNormalized = normalizeAttrsDeep({ ...(documentBody as ComarkTree), frontmatter: {} })
+    const generatedNormalized = normalizeAttrsDeep({ ...(generatedDocument.body as ComarkTree), frontmatter: {} })
+    const documentNormalized = normalizeAttrsDeep({ ...(document.body as ComarkTree), frontmatter: {} })
     const generatedBodyStringified = (await renderMarkdown(generatedNormalized)).replace(/\n/g, '')
     const documentBodyStringified = (await renderMarkdown(documentNormalized)).replace(/\n/g, '')
     if (generatedBodyStringified !== documentBodyStringified) {

--- a/src/module/src/runtime/utils/document/compare.ts
+++ b/src/module/src/runtime/utils/document/compare.ts
@@ -4,6 +4,7 @@ import { ContentFileExtension } from '../../types/content'
 import { doObjectsMatch } from '../object'
 import { renderMarkdown } from 'comark/render'
 import { documentFromContent } from './generate'
+import { cleanDataKeys } from './schema'
 
 /**
  * Sort and normalize every element's attributes alphabetically.
@@ -42,7 +43,13 @@ export async function isDocumentMatchingContent(content: string, document: Datab
       return false
     }
 
-    return doObjectsMatch(generatedDocumentData, documentData)
+    // @nuxt/content may store unknown frontmatter fields in `meta` rather than as top-level
+    // columns depending on the collection schema. cleanDataKeys expands meta to root and strips
+    // nulls/defaults, matching the normalization used by contentFromMarkdownDocument.
+    return doObjectsMatch(
+      cleanDataKeys(generatedDocument) as Record<string, unknown>,
+      cleanDataKeys(document) as Record<string, unknown>,
+    )
   }
 
   return doObjectsMatch(generatedDocument, document)

--- a/src/module/src/runtime/utils/document/compare.ts
+++ b/src/module/src/runtime/utils/document/compare.ts
@@ -43,9 +43,7 @@ export async function isDocumentMatchingContent(content: string, document: Datab
       return false
     }
 
-    // @nuxt/content may store unknown frontmatter fields in `meta` rather than as top-level
-    // columns depending on the collection schema. cleanDataKeys expands meta to root and strips
-    // nulls/defaults, matching the normalization used by contentFromMarkdownDocument.
+    // @nuxt/content may store unknown frontmatter fields in `meta` instead of top-level columns.
     return doObjectsMatch(
       cleanDataKeys(generatedDocument) as Record<string, unknown>,
       cleanDataKeys(document) as Record<string, unknown>,

--- a/src/module/test/utils/document.test.ts
+++ b/src/module/test/utils/document.test.ts
@@ -464,9 +464,6 @@ Description`
   })
 
   it('should be true when frontmatter fields are stored in meta by @nuxt/content instead of top-level', async () => {
-    // @nuxt/content may store unknown frontmatter keys (not in collection schema) inside `meta`
-    // rather than as top-level columns. isDocumentMatchingContent must handle this the same
-    // way contentFromMarkdownDocument does (via cleanDataKeys meta expansion).
     const markdownContent = `---
 title: Test Page
 navigation: hidden
@@ -484,7 +481,6 @@ Hello world
       extension: ContentFileExtension.Markdown,
       stem: 'pages/test',
       title: 'Test Page',
-      // @nuxt/content stored navigation and sitemap in meta because they weren't schema columns
       meta: {
         navigation: 'hidden',
         sitemap: { loc: '/test', images: [], videos: [] },

--- a/src/module/test/utils/document.test.ts
+++ b/src/module/test/utils/document.test.ts
@@ -462,6 +462,39 @@ Description`
     const result = await isDocumentMatchingContent(jsonContent, document)
     expect(result).toBe(true)
   })
+
+  it('should be true when frontmatter fields are stored in meta by @nuxt/content instead of top-level', async () => {
+    // @nuxt/content may store unknown frontmatter keys (not in collection schema) inside `meta`
+    // rather than as top-level columns. isDocumentMatchingContent must handle this the same
+    // way contentFromMarkdownDocument does (via cleanDataKeys meta expansion).
+    const markdownContent = `---
+title: Test Page
+navigation: hidden
+sitemap:
+  loc: /test
+  images: []
+  videos: []
+---
+
+Hello world
+`
+
+    const document = {
+      id: 'content:pages/test.md',
+      extension: ContentFileExtension.Markdown,
+      stem: 'pages/test',
+      title: 'Test Page',
+      // @nuxt/content stored navigation and sitemap in meta because they weren't schema columns
+      meta: {
+        navigation: 'hidden',
+        sitemap: { loc: '/test', images: [], videos: [] },
+      },
+      body: { nodes: [['p', {}, 'Hello world']], frontmatter: {}, meta: {} },
+    } as unknown as DatabaseItem
+
+    const result = await isDocumentMatchingContent(markdownContent, document)
+    expect(result).toBe(true)
+  })
 })
 
 describe('sanitizeDocumentTree', () => {


### PR DESCRIPTION
## Problem

When opening certain pages in Studio, a false conflict dialog appeared showing a diff between the "GitHub" and "Website" versions — even though the file hadn't actually changed remotely.

The root cause: `@nuxt/content` stores frontmatter fields that aren't defined in the collection schema inside `document.meta` rather than as top-level columns. For example, a page with `navigation: hidden` and a `sitemap:` block in its frontmatter would end up with those fields at `document.meta.navigation` and `document.meta.sitemap` rather than `document.navigation` / `document.sitemap`.

`checkConflict` calls `isDocumentMatchingContent` to check whether the stored document still matches the remote file. This function re-parses the raw remote markdown via `documentFromContent`, which puts all frontmatter at top level. It then called `doObjectsMatch(generatedDocumentData, documentData)`, where `generatedDocumentData` had all keys at the top level but `documentData` (the stored document) had some of them tucked inside `meta`. `doObjectsMatch` iterates over the `base` (generated) side's keys and treats missing values on the `target` (stored) side as mismatches — so it returned `false`, triggering the conflict path, even though no real change had occurred.

## Fix

The rendering path (`contentFromMarkdownDocument`) already calls `cleanDataKeys` on the stored document before producing markdown from it. `cleanDataKeys` expands `meta` to root level, strips reserved keys (`id`, `stem`, `path`, `__hash__`, etc.), removes top-level nulls and empty arrays, and normalises navigation/seo defaults.

I applied the same normalization to both sides inside `isDocumentMatchingContent`:

```ts
// Before
return doObjectsMatch(generatedDocumentData, documentData)

// After
return doObjectsMatch(
  cleanDataKeys(generatedDocument) as Record<string, unknown>,
  cleanDataKeys(document) as Record<string, unknown>,
)
```

This brings the conflict check in line with what the rest of the pipeline sees, so a stored document and a freshly-parsed document of the same content are structurally equivalent before comparison — regardless of whether @nuxt/content chose to store certain fields at top level or inside `meta`.

Note that `areDocumentsEqual` (used elsewhere) already handled this correctly by spreading `{ ...documentData, ...(meta || {}) }` before comparing. `isDocumentMatchingContent` was the outlier.