### PR TITLE
fix(tiptap): preserve YAML array-of-objects component props in round-trip

### DIFF
--- a/playground/docus/content/3.pages/authors.md
+++ b/playground/docus/content/3.pages/authors.md
@@ -27,24 +27,20 @@ authorsOne:
   - name: John Doe One
     avatar: https://placehold.co/150
     role: contributor
-    bio: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua.
+    bio: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
   - name: Jane Doe One
     avatar: https://placehold.co/150
     role: creator
-    bio: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua.
+    bio: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 authorsTwo:
   - name: John Doe Two
     avatar: https://placehold.co/150
     role: maintainer
-    bio: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua.
+    bio: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
   - name: Jane Doe Two
     avatar: https://placehold.co/150
     role: contributor
-    bio: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua.
+    bio: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 ---
 ::
 

--- a/src/app/src/utils/tiptap/props.ts
+++ b/src/app/src/utils/tiptap/props.ts
@@ -5,6 +5,7 @@ import type { JSType } from 'untyped'
 import type { FormItem, FormTree } from '../../types'
 import type { ComponentMeta } from '../../types/editor'
 import type { PropertyMeta, PropertyMetaSchema } from 'vue-component-meta'
+import type { ComarkElementAttributes } from 'comark'
 
 const HIDDEN_PROPS = [
   'ui',
@@ -139,18 +140,19 @@ export function buildAttrs<V = unknown, K extends string = string>(
 }
 
 /**
- * Process and normalize element props, preserving className as array
+ * Merge node props with extra props for a ComarkElement, trimming keys and
+ * dropping empty ones. Values are passed through untouched — comark attrs are
+ * already correctly typed (strings, arrays, objects) and comark serializes each
+ * type itself, so no stringification is needed or wanted (stringifying would
+ * collapse arrays/objects into `"[object Object]"`).
  */
-export function normalizeProps(nodeProps: Record<string, unknown>, extraProps: object): Array<[string, string | string[]]> {
-  return Object.entries({ ...nodeProps, ...extraProps })
-    .map(([key, value]) => {
-      if (key === 'className') {
-        // Keep className as array if it's already an array
-        return ['className', value] as [string, string | string[]]
-      }
-      return [key.trim(), String(value).trim()] as [string, string]
-    })
-    .filter(([key]) => Boolean(String(key).trim()))
+export function normalizeProps(nodeProps: Record<string, unknown>, extraProps: object): ComarkElementAttributes {
+  const out: ComarkElementAttributes = {}
+  for (const [rawKey, value] of Object.entries({ ...nodeProps, ...extraProps })) {
+    const key = rawKey.trim()
+    if (key) out[key] = value
+  }
+  return out
 }
 
 export const buildFormTreeFromProps = (node: ProseMirrorNode, componentMeta: ComponentMeta): FormTree => {

--- a/src/app/src/utils/tiptap/tiptapToComark.ts
+++ b/src/app/src/utils/tiptap/tiptapToComark.ts
@@ -1,6 +1,6 @@
 import type { JSONContent } from '@tiptap/vue-3'
 import Slugger from 'github-slugger'
-import type { ComarkTree, ComarkNode, ComarkElement, ComarkComment } from 'comark'
+import type { ComarkTree, ComarkNode, ComarkElement, ComarkComment, ComarkElementAttributes } from 'comark'
 import type { SyntaxHighlightTheme } from '../../types/content'
 import { getEmojiUnicode } from '../emoji'
 import { buildAttrs, cleanSpanProps, normalizeProps } from './props'
@@ -197,27 +197,26 @@ function createElement(node: JSONContent, tag?: string, extra: unknown = {}): Co
   }
 
   // Process element props
-  const propsArray = normalizeProps(node.attrs?.props || {}, props)
+  const elementProps = normalizeProps(node.attrs?.props || {}, props)
   if (node.type === 'paragraph') {
     // Empty paragraph
     if (!children || children.length === 0) {
       return ['p', {}] as ComarkElement
     }
     // Create paragraph element
-    return createParagraphElement(node, propsArray, rest)
+    return createParagraphElement(node, elementProps, rest)
   }
 
   children = unwrapDefaultSlot(children)
   children = unwrapParagraph(children)
   children = wrapImageInParagraph(children)
 
-  const elementProps = Object.fromEntries(propsArray)
   const elementChildren = (node.children || comarkNodesFromTiptap(children)) as ComarkNode[]
 
   return [tag || node.attrs?.tag, elementProps, ...elementChildren] as ComarkElement
 }
 
-function createParagraphElement(node: JSONContent, propsArray: Array<[string, string | string[]]>, _rest: object = {}): ComarkElement {
+function createParagraphElement(node: JSONContent, props: ComarkElementAttributes, _rest: object = {}): ComarkElement {
   const blocks: Array<{ mark: { type: string, attrs?: Record<string, unknown> } | null, content: JSONContent[] }> = []
   let currentBlockContent: JSONContent[] = []
   let currentBlockMark: { type: string, attrs?: Record<string, unknown> } | null = null
@@ -289,7 +288,7 @@ function createParagraphElement(node: JSONContent, propsArray: Array<[string, st
   const flatChildren = (children as Array<ComarkElement | ComarkNode[]>).flat() as ComarkNode[]
   const mergedChildren = mergeSiblingsWithSameTag(flatChildren, Object.values(markToTag))
 
-  return ['p', Object.fromEntries(propsArray), ...mergedChildren] as ComarkElement
+  return ['p', props, ...mergedChildren] as ComarkElement
 }
 
 function createHeadingElement(node: JSONContent): ComarkElement {

--- a/src/app/test/integration/tiptap.test.ts
+++ b/src/app/test/integration/tiptap.test.ts
@@ -2682,3 +2682,59 @@ text 1
     expect(outputContentBis).toBe(`${inputContent}\n`)
   })
 })
+
+describe('YAML array-of-objects props round-trip', () => {
+  test('block element with YAML array-of-objects props round-trips correctly', async () => {
+    const inputContent = `::authors
+---
+authorsOne:
+  - name: John Doe One
+    avatar: https://placehold.co/150
+    role: contributor
+authorsTwo:
+  - name: Jane Doe Two
+    avatar: https://placehold.co/150
+    role: maintainer
+---
+::`
+
+    const expectedComarkNodes = [
+      [
+        'authors',
+        {
+          authorsOne: [{ name: 'John Doe One', avatar: 'https://placehold.co/150', role: 'contributor' }],
+          authorsTwo: [{ name: 'Jane Doe Two', avatar: 'https://placehold.co/150', role: 'maintainer' }],
+        },
+      ],
+    ]
+
+    const document = await documentFromContent('test.md', inputContent) as DatabasePageItem
+    const comarkTree = document.body
+
+    // AST must contain actual objects, not JSON strings
+    expect(comarkTree.nodes).toMatchObject(expectedComarkNodes)
+
+    const tiptapJSON: JSONContent = comarkToTiptap(comarkTree)
+
+    // TipTap attrs.props must still hold actual objects (not "[object Object]")
+    const elementNode = tiptapJSON.content?.find(n => n.type === 'element')
+    expect(elementNode?.attrs?.props?.authorsOne).toEqual([
+      { name: 'John Doe One', avatar: 'https://placehold.co/150', role: 'contributor' },
+    ])
+
+    const rtComarkTree = await tiptapToComark(tiptapJSON)
+
+    // After round-trip the AST must still hold actual objects
+    expect(rtComarkTree.nodes).toMatchObject(expectedComarkNodes)
+
+    const generatedDocument = createMockDocument('docs/test.md', {
+      body: rtComarkTree,
+      ...rtComarkTree.frontmatter,
+    })
+
+    const outputContent = await contentFromDocument(generatedDocument)
+
+    // Output must use YAML block syntax, not inline JSON strings
+    expect(outputContent).toBe(`${inputContent}\n`)
+  })
+})

--- a/src/app/test/unit/utils/tiptap/props.test.ts
+++ b/src/app/test/unit/utils/tiptap/props.test.ts
@@ -1440,7 +1440,7 @@ describe('props', () => {
     })
 
     test('drops empty and whitespace-only keys', () => {
-      expect(normalizeProps({ '': 'a', '   ': 'b', valid: 'c' }, {})).toEqual({ valid: 'c' })
+      expect(normalizeProps({ '': 'a', '   ': 'b', 'valid': 'c' }, {})).toEqual({ valid: 'c' })
     })
 
     test('merges nodeProps and extraProps, extraProps wins on collision', () => {

--- a/src/app/test/unit/utils/tiptap/props.test.ts
+++ b/src/app/test/unit/utils/tiptap/props.test.ts
@@ -2,7 +2,7 @@ import { expect, test, describe } from 'vitest'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import type { JSType } from 'untyped'
 import type { PropertyMeta } from 'vue-component-meta'
-import { buildAttrs, buildFormTreeFromProps, convertStringToArray, convertStringToValue } from '../../../../src/utils/tiptap/props'
+import { buildAttrs, buildFormTreeFromProps, convertStringToArray, convertStringToValue, normalizeProps } from '../../../../src/utils/tiptap/props'
 import { buttonPropsSchema, iconPropsSchema } from '../../../mocks/props'
 import type { ComponentMeta } from '../../../../src/types/component'
 
@@ -1397,6 +1397,55 @@ describe('props', () => {
     //     },
     //   })
     // })
+  })
+
+  describe('normalizeProps', () => {
+    test('passes array-of-objects values through unchanged', () => {
+      const authors = [
+        { name: 'John Doe', role: 'contributor', avatar: 'https://placehold.co/150' },
+        { name: 'Jane Doe', role: 'creator', avatar: 'https://placehold.co/150' },
+      ]
+      expect(normalizeProps({ authorsOne: authors }, {})).toEqual({ authorsOne: authors })
+    })
+
+    test('passes plain object values through unchanged', () => {
+      const config = { key1: 'value1', key2: 'value2' }
+      expect(normalizeProps({ objectAttr: config }, {})).toEqual({ objectAttr: config })
+    })
+
+    test('passes array-of-primitives through unchanged', () => {
+      const tags = ['important', 'archived', 'urgent']
+      expect(normalizeProps({ tags }, {})).toEqual({ tags })
+    })
+
+    test('passes null through unchanged', () => {
+      expect(normalizeProps({ optional: null }, {})).toEqual({ optional: null })
+    })
+
+    test('passes primitive values through unchanged (no stringification)', () => {
+      // Values are already the correct type from comark parse — no coercion wanted
+      expect(normalizeProps({ title: 'Hello', count: 42, enabled: true }, {})).toEqual({
+        title: 'Hello',
+        count: 42,
+        enabled: true,
+      })
+    })
+
+    test('passes className array through unchanged', () => {
+      expect(normalizeProps({ className: ['foo', 'bar'] }, {})).toEqual({ className: ['foo', 'bar'] })
+    })
+
+    test('trims whitespace from keys', () => {
+      expect(normalizeProps({ '  title  ': 'Hello' }, {})).toEqual({ title: 'Hello' })
+    })
+
+    test('drops empty and whitespace-only keys', () => {
+      expect(normalizeProps({ '': 'a', '   ': 'b', valid: 'c' }, {})).toEqual({ valid: 'c' })
+    })
+
+    test('merges nodeProps and extraProps, extraProps wins on collision', () => {
+      expect(normalizeProps({ a: 1, b: 2 }, { b: 99, c: 3 })).toEqual({ a: 1, b: 99, c: 3 })
+    })
   })
 
   describe('buildAttrs', () => {

--- a/src/module/src/runtime/utils/document/legacy.ts
+++ b/src/module/src/runtime/utils/document/legacy.ts
@@ -312,6 +312,25 @@ function normalizeMdcChildren(children: MDCNode[]): MDCNode[] {
 function propsMDCToComark(tag: string, props: Record<string, unknown>): Record<string, unknown> {
   let next: Record<string, unknown> = props
 
+  // @nuxtjs/mdc serializes non-primitive YAML block props (arrays, objects) as
+  // Vue binding syntax: key ":authorsOne" + JSON-stringified value. Unwrap these
+  // back to plain keys with their real JavaScript values.
+  const unbound: Record<string, unknown> = {}
+  for (const [rawKey, value] of Object.entries(next)) {
+    if (rawKey.startsWith(':') && typeof value === 'string') {
+      try {
+        unbound[rawKey.slice(1)] = JSON.parse(value)
+      }
+      catch {
+        unbound[rawKey] = value
+      }
+    }
+    else {
+      unbound[rawKey] = value
+    }
+  }
+  next = unbound
+
   if (tag === 'template') {
     const vSlotKey = Object.keys(next).find(k => k.startsWith('v-slot:'))
     if (vSlotKey) {

--- a/src/module/test/utils/legacy.test.ts
+++ b/src/module/test/utils/legacy.test.ts
@@ -781,6 +781,59 @@ describe('comark → mdc reverse helpers (used at DB write boundary)', () => {
     expect(slot[1]).toEqual({ name: 'title' })
   })
 
+  it('unwraps @nuxtjs/mdc binding-syntax props (:key + JSON string) to real JS values', () => {
+    // @nuxtjs/mdc serialises array-of-objects YAML block props as:
+    //   { ":authorsOne": "[{\"name\":\"John\"}]" }
+    // propsMDCToComark must unwrap these back to { authorsOne: [{name:'John'}] }
+    const mdcBody: MDCRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tag: 'authors',
+          props: {
+            ':authorsOne': '[{"name":"John Doe","role":"contributor"}]',
+            ':authorsTwo': '[{"name":"Jane Doe","role":"maintainer"}]',
+          },
+          children: [],
+        } as unknown,
+      ],
+    } as MDCRoot
+
+    const tree = comarkTreeFromLegacyDocument(legacyDocument(mdcBody))!
+    const [, attrs] = tree.nodes[0] as [string, Record<string, unknown>]
+
+    expect(attrs.authorsOne).toEqual([{ name: 'John Doe', role: 'contributor' }])
+    expect(attrs.authorsTwo).toEqual([{ name: 'Jane Doe', role: 'maintainer' }])
+    expect(':authorsOne' in attrs).toBe(false)
+    expect(':authorsTwo' in attrs).toBe(false)
+  })
+
+  it('round-trips array-of-objects props through the legacy bridge and renders YAML block', async () => {
+    const mdcBody: MDCRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tag: 'authors',
+          props: {
+            ':authorsOne': '[{"name":"John Doe","role":"contributor"}]',
+          },
+          children: [],
+        } as unknown,
+      ],
+    } as MDCRoot
+
+    const tree = comarkTreeFromLegacyDocument(legacyDocument(mdcBody))!
+    const markdown = await renderMarkdown(tree, { blockAttributesStyle: 'frontmatter' })
+
+    // Must use YAML block format, not inline JSON binding syntax
+    expect(markdown).toContain('authorsOne:')
+    expect(markdown).toContain('- name: John Doe')
+    expect(markdown).not.toContain(':authorsOne=')
+    expect(markdown).not.toContain('[object Object]')
+  })
+
   it('writes back `class` strings as `className` arrays', () => {
     const tree: ComarkTree = {
       nodes: [['span', { class: 'text-primary font-bold' }, 'Nuxt']],


### PR DESCRIPTION
## Problem

Editing a component with YAML block array-of-objects props in Studio corrupts them on save:

```md
::authors
---
authorsOne:
  - name: John Doe
    role: contributor
---
::
```

becomes:

```md
::authors{:authorsOne="[{"name":"John Doe","role":"contributor"}]"}
::
```

Closes #457. Supersedes #477.

## Root cause (two bugs)

### 1. `propsMDCToComark` didn't unwrap `@nuxtjs/mdc` binding-syntax props

`@nuxtjs/mdc` serialises non-primitive YAML block props (arrays, objects) as Vue binding syntax — key `:authorsOne` (`:` prefix) with a JSON-stringified string value `"[{\"name\":\"John\"}]"`. The `propsMDCToComark` bridge in `legacy.ts` passed these through unchanged, so the entire pipeline carried a JSON string instead of a real JavaScript array. When comark rendered the ComarkElement back to markdown, it emitted the inline binding form `{:authorsOne="[...]"}` — exactly the corruption seen in production.

### 2. `normalizeProps` was built on a "all props are strings" assumption

`String(value).trim()` on every prop value was wrong in principle. Comark attrs are already the correct type from the parser (`string` for inline attrs, `number`/`boolean`/`array`/`object` for YAML block attrs), and comark's renderer handles all these types natively. The stringification was a latent correctness bug even when it wasn't the immediate cause of corruption.

## Fix

**`legacy.ts` — `propsMDCToComark`** (root cause fix): detect `:key` binding props produced by `@nuxtjs/mdc` and `JSON.parse` their values back to real JavaScript values, stripping the `:` prefix.

**`props.ts` — `normalizeProps`** (type correctness): rewritten to pass values through untouched, returning `ComarkElementAttributes` directly instead of `Array<[string, unknown]>`. Key trimming and empty-key filtering are preserved — they guard against user-typed custom props from the form editor which may have stray whitespace.

**`tiptapToComark.ts`**: both call sites updated — `Object.fromEntries(propsArray)` middleman removed since `normalizeProps` now returns the attrs object directly.

## Test plan

- [x] Unit tests for `normalizeProps`: values pass through as their original type (number stays number, array stays array, null stays null); key trimming and empty-key filtering work
- [x] Unit tests for `propsMDCToComark`: `:key` bindings are unwrapped to real JS values; full round-trip through the legacy bridge renders YAML block format, not inline JSON
- [x] Integration test: full comark → TipTap → comark → markdown round-trip with YAML array-of-objects props preserves structure and renders correct YAML block output
- [x] All 347 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)