### PR TITLE
feat(repository): add feature-branch publish strategy

### DIFF
--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -202,6 +202,23 @@ export default defineNuxtConfig({
 })
 ```
 
+#### Branch Strategy `default: 'direct'`
+
+By default, Studio commits directly to the configured branch. Set `branchStrategy` to `'feature-branch'` to create a new `studio/YYYY-MM-DD-HH-MM-SS` branch for every publish action instead:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  studio: {
+    repository: {
+      ...
+      branchStrategy: 'feature-branch'
+    }
+  }
+})
+```
+
+This is useful when you want content changes to go through a pull request review before they are merged into the main branch.
+
 #### Private Repository Access `default: true`
 
 By default, Studio requests access to both public and private repositories.

--- a/src/app/src/composables/useStudio.ts
+++ b/src/app/src/composables/useStudio.ts
@@ -33,6 +33,7 @@ export const useStudio = createSharedComposable(() => {
     authorName: host.user.get().name,
     authorEmail: host.user.get().email,
     instanceUrl: host.repository.instanceUrl,
+    branchStrategy: host.repository.branchStrategy,
   }
 
   const gitProvider = useGitProvider(gitOptions, devMode.value)

--- a/src/app/src/types/git.ts
+++ b/src/app/src/types/git.ts
@@ -14,6 +14,13 @@ export interface Repository {
    * @default 'https://gitlab.com'
    */
   instanceUrl?: string
+  /**
+   * Controls where Studio commits content changes.
+   * - `'direct'`: commit directly to the configured branch (default)
+   * - `'feature-branch'`: create a new `studio/YYYY-MM-DD-HH-MM-SS` branch for every publish
+   * @default 'direct'
+   */
+  branchStrategy?: 'direct' | 'feature-branch'
 }
 
 export interface GitBaseOptions {
@@ -29,6 +36,7 @@ export interface GitOptions extends GitBaseOptions {
   rootDir: string
   token: string
   instanceUrl?: string
+  branchStrategy?: 'direct' | 'feature-branch'
 }
 
 export interface CommitFilesOptions extends GitBaseOptions {
@@ -57,6 +65,7 @@ export interface CommitResult {
   success: boolean
   commitSha: string
   url: string
+  branch?: string
 }
 
 export interface GitFile {

--- a/src/app/src/utils/providers/github.ts
+++ b/src/app/src/utils/providers/github.ts
@@ -14,8 +14,13 @@ interface GitHubUser {
 const NUXT_STUDIO_COAUTHOR = 'Co-authored-by: Nuxt Studio <noreply@nuxt.studio>'
 const logger = consola.withTag('Nuxt Studio')
 
+function featureBranchName(): string {
+  return `studio/${new Date().toISOString().slice(0, 19).replace(/[T:]/g, '-')}`
+}
+
 export function createGitHubProvider(options: GitOptions): GitProviderAPI {
   const { owner, repo, token, branch, rootDir, authorName, authorEmail } = options
+  const useFeatureBranch = options.branchStrategy === 'feature-branch'
   const gitFiles: Record<string, GitFile> = {}
 
   const instanceUrl = withoutTrailingSlash(options.instanceUrl || 'https://github.com')
@@ -157,15 +162,27 @@ export function createGitHubProvider(options: GitOptions): GitProviderAPI {
       ? `${message}\n\n${coAuthors.join('\n')}`
       : message
 
-    return commitFilesToGitHub({
+    let targetBranch = branch
+    if (useFeatureBranch) {
+      targetBranch = featureBranchName()
+      const refData = await $repositoryApi(`/git/refs/heads/${branch}`)
+      await $repositoryApi(`/git/refs`, {
+        method: 'POST',
+        body: JSON.stringify({ ref: `refs/heads/${targetBranch}`, sha: refData.object.sha }),
+      })
+    }
+
+    const result = await commitFilesToGitHub({
       owner,
       repo,
-      branch,
+      branch: targetBranch,
       files,
       message: fullMessage,
       authorName: commitAuthorName,
       authorEmail: commitAuthorEmail,
     })
+
+    return result ? { ...result, branch: useFeatureBranch ? targetBranch : undefined } : null
   }
 
   async function commitFilesToGitHub({ owner, repo, branch, files, message, authorName, authorEmail }: CommitFilesOptions) {

--- a/src/app/src/utils/providers/gitlab.ts
+++ b/src/app/src/utils/providers/gitlab.ts
@@ -29,8 +29,13 @@ function normalizeGitLabBase64Payload(content: string): string {
   return content.slice(markerIndex + base64Marker.length)
 }
 
+function featureBranchName(): string {
+  return `studio/${new Date().toISOString().slice(0, 19).replace(/[T:]/g, '-')}`
+}
+
 export function createGitLabProvider(options: GitOptions): GitProviderAPI {
   const { owner, repo, token, branch, rootDir, authorName, authorEmail, instanceUrl = 'https://gitlab.com' } = options
+  const useFeatureBranch = options.branchStrategy === 'feature-branch'
   const gitFiles: Record<string, GitFile> = {}
 
   // Remove trailing slash from instanceUrl if present
@@ -102,7 +107,7 @@ export function createGitLabProvider(options: GitOptions): GitProviderAPI {
     }
   }
 
-  function commitFiles(files: RawFile[], message: string): Promise<CommitResult | null> {
+  async function commitFiles(files: RawFile[], message: string): Promise<CommitResult | null> {
     if (!token) {
       return Promise.resolve(null)
     }
@@ -111,18 +116,23 @@ export function createGitLabProvider(options: GitOptions): GitProviderAPI {
       .filter(file => file.status !== DraftStatus.Pristine)
       .map(file => ({ ...file, path: joinURL(rootDir, file.path) }))
 
-    return commitFilesToGitLab({
+    const targetBranch = useFeatureBranch ? featureBranchName() : branch
+
+    const result = await commitFilesToGitLab({
       owner,
       repo,
-      branch,
+      branch: targetBranch,
       files,
       message,
       authorName,
       authorEmail,
+      baseBranch: useFeatureBranch ? branch : undefined,
     })
+
+    return result ? { ...result, branch: useFeatureBranch ? targetBranch : undefined } : null
   }
 
-  async function commitFilesToGitLab({ branch, files, message, authorName, authorEmail }: CommitFilesOptions) {
+  async function commitFilesToGitLab({ branch, files, message, authorName, authorEmail, baseBranch }: CommitFilesOptions & { baseBranch?: string }) {
     // GitLab uses a single commits API with actions
     const actions = files.map((file) => {
       if (file.status === DraftStatus.Deleted) {
@@ -157,6 +167,7 @@ export function createGitLabProvider(options: GitOptions): GitProviderAPI {
       method: 'POST',
       body: {
         branch,
+        ...(baseBranch ? { start_branch: baseBranch } : {}),
         commit_message: message,
         actions,
         author_name: authorName,

--- a/src/module/src/module.ts
+++ b/src/module/src/module.ts
@@ -125,6 +125,13 @@ interface RepositoryOptions {
    * @default true
    */
   private?: boolean
+  /**
+   * Controls where Studio commits content changes.
+   * - `'direct'`: commit directly to the configured branch (default behaviour)
+   * - `'feature-branch'`: create a new `studio/YYYY-MM-DD-HH-MM-SS` branch for every publish action
+   * @default 'direct'
+   */
+  branchStrategy?: 'direct' | 'feature-branch'
 }
 
 interface GitHubRepositoryOptions extends RepositoryOptions {


### PR DESCRIPTION
At FlowFuse we use a public handbook which we want to transition to use Nuxt and Nuxt Studio for content updates. However, as a handbook is in some way the law, it needs to be approved and merged. As such, feature branches would be required.

This PR adds `branchStrategy: 'feature-branch'` to the `studio.repository` config. If set the publishing creates a `studio/YYYY-MM-DD-HH-MM-SS` branch. The seconds are included to avoid collisions.