### PR TITLE
chore(tiptap): remove stale @ts-expect-error directives

### DIFF
--- a/src/app/src/components/tiptap/extension/TiptapExtensionElement.vue
+++ b/src/app/src/components/tiptap/extension/TiptapExtensionElement.vue
@@ -9,7 +9,6 @@ import { standardNuxtUIComponents } from '../../../utils/tiptap/editor'
 
 const nodeProps = defineProps(nodeViewProps)
 
-// @ts-expect-error vue-tsc error in cli
 const nodeViewContent = ref<HTMLElement>()
 
 const node = computed(() => nodeProps.node)

--- a/src/app/src/components/tiptap/extension/TiptapExtensionElement.vue
+++ b/src/app/src/components/tiptap/extension/TiptapExtensionElement.vue
@@ -9,8 +9,6 @@ import { standardNuxtUIComponents } from '../../../utils/tiptap/editor'
 
 const nodeProps = defineProps(nodeViewProps)
 
-const nodeViewContent = ref<HTMLElement>()
-
 const node = computed(() => nodeProps.node)
 
 const { host } = useStudio()
@@ -192,7 +190,7 @@ function updateComponentProps(props: Record<string, unknown>) {
       v-show="!collapsed"
       class="ml-5 mt-2"
     >
-      <NodeViewContent ref="nodeViewContent" />
+      <NodeViewContent />
     </div>
   </NodeViewWrapper>
 </template>

--- a/src/app/src/components/tiptap/extension/TiptapExtensionSlot.vue
+++ b/src/app/src/components/tiptap/extension/TiptapExtensionSlot.vue
@@ -7,7 +7,6 @@ const nodeProps = defineProps(nodeViewProps)
 
 const { host } = useStudio()
 
-// @ts-expect-error vue-tsc error in cli
 const nodeViewContentEl = ref<HTMLElement>()
 
 const isHovered = ref(false)

--- a/src/app/src/components/tiptap/extension/TiptapExtensionSlot.vue
+++ b/src/app/src/components/tiptap/extension/TiptapExtensionSlot.vue
@@ -7,8 +7,6 @@ const nodeProps = defineProps(nodeViewProps)
 
 const { host } = useStudio()
 
-const nodeViewContentEl = ref<HTMLElement>()
-
 const isHovered = ref(false)
 const isEditable = ref(true) // TODO: Connect to editor state
 
@@ -92,7 +90,7 @@ function deleteSlot() {
       <div
         class="pl-5 border-l-2 border-dashed border-default"
       >
-        <NodeViewContent ref="nodeViewContentEl" />
+        <NodeViewContent />
       </div>
     </div>
   </NodeViewWrapper>


### PR DESCRIPTION
## Summary

- Remove two unused `ref<HTMLElement>()` declarations (`nodeViewContent`, `nodeViewContentEl`) from `TiptapExtensionElement.vue` and `TiptapExtensionSlot.vue` — these were never read in script, only attached as template `ref=` attributes with no downstream usage
- Remove the corresponding `ref=` attributes from the templates
- Remove the `// @ts-expect-error vue-tsc error in cli` comments that were masking the underlying TS6133 errors

## Test plan

- [x] Run `pnpm typecheck` — should pass cleanly
- [x] Verify TipTap element and slot node views still render correctly in the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)