### PR TITLE
fix(tiptap): don't add default slot when inserting slotless components

### DIFF
--- a/src/app/src/components/content/editor/ContentEditorTipTap.vue
+++ b/src/app/src/components/content/editor/ContentEditorTipTap.vue
@@ -11,6 +11,7 @@ import { comarkToTiptap } from '../../../utils/tiptap/comarkToTiptap'
 import { tiptapToComark } from '../../../utils/tiptap/tiptapToComark'
 import { removeLastEmptyParagraph } from '../../../utils/tiptap/editor'
 import { Element } from '../../../utils/tiptap/extensions/element'
+import { pickInitialSlot } from '../../../utils/tiptap/handlers'
 import { Image } from '../../../utils/tiptap/extensions/image'
 import { ImagePicker } from '../../../utils/tiptap/extensions/image-picker'
 import { VideoPicker } from '../../../utils/tiptap/extensions/video-picker'
@@ -164,7 +165,9 @@ watch(() => `${document.value?.id}-${props.draftItem.version}-${props.draftItem.
         VideoPicker,
         Video,
         ...(hasNuxtUI ? [Callout] : []),
-        Element,
+        Element.configure({
+          resolveInitialSlot: tag => pickInitialSlot(host.meta.editor.components.get().find(c => c.name === tag)?.meta.slots),
+        }),
         InlineElement,
         SpanStyle,
         Slot,

--- a/src/app/src/composables/useTiptapEditor.ts
+++ b/src/app/src/composables/useTiptapEditor.ts
@@ -13,7 +13,7 @@ import {
   standardNuxtUIComponents,
   computeStandardDragActions,
 } from '../utils/tiptap/editor'
-import { imageHandler, videoHandler, calloutHandler, componentHandler, tableHandler, CALLOUT_TYPES } from '../utils/tiptap/handlers'
+import { imageHandler, videoHandler, calloutHandler, componentHandler, tableHandler, CALLOUT_TYPES, pickInitialSlot } from '../utils/tiptap/handlers'
 import { useStudio } from './useStudio'
 
 const NATIVE_OVERRIDE_COMPONENTS = new Set(['table'])
@@ -50,10 +50,14 @@ export function useTiptapEditor() {
     video: videoHandler(),
     table: tableHandler(),
     ...Object.fromEntries(
-      componentItems.value.map(item => [
-        item.kind,
-        CALLOUT_TYPES.has(item.kind) ? calloutHandler(item.kind) : componentHandler(item.kind),
-      ]),
+      host.meta.editor.components.get()
+        .filter(component => !NATIVE_OVERRIDE_COMPONENTS.has(component.name))
+        .map(component => [
+          component.name,
+          CALLOUT_TYPES.has(component.name)
+            ? calloutHandler(component.name)
+            : componentHandler(component.name, pickInitialSlot(component.meta.slots)),
+        ]),
     ),
   }) satisfies EditorCustomHandlers)
 

--- a/src/app/src/composables/useTiptapEditor.ts
+++ b/src/app/src/composables/useTiptapEditor.ts
@@ -39,6 +39,7 @@ export function useTiptapEditor() {
         type: undefined as never,
         label: titleCase(component.name),
         icon: standardNuxtUIComponents[component.name]?.icon || 'i-lucide-box',
+        slots: component.meta.slots,
       }))
   })
 
@@ -50,14 +51,12 @@ export function useTiptapEditor() {
     video: videoHandler(),
     table: tableHandler(),
     ...Object.fromEntries(
-      host.meta.editor.components.get()
-        .filter(component => !NATIVE_OVERRIDE_COMPONENTS.has(component.name))
-        .map(component => [
-          component.name,
-          CALLOUT_TYPES.has(component.name)
-            ? calloutHandler(component.name)
-            : componentHandler(component.name, pickInitialSlot(component.meta.slots)),
-        ]),
+      componentItems.value.map(item => [
+        item.kind,
+        CALLOUT_TYPES.has(item.kind)
+          ? calloutHandler(item.kind)
+          : componentHandler(item.kind, pickInitialSlot(item.slots)),
+      ]),
     ),
   }) satisfies EditorCustomHandlers)
 

--- a/src/app/src/utils/tiptap/extensions/element.ts
+++ b/src/app/src/utils/tiptap/extensions/element.ts
@@ -70,7 +70,13 @@ export const Element = Node.create<ElementOptions>({
           const value: Content = {
             type: 'element',
             attrs: { tag },
-            ...(slot ? { content: [{ type: 'slot', attrs: { name: slot }, content: [{ type: 'paragraph', content: [] }] }] } : {}),
+          }
+          if (slot) {
+            value.content = [{
+              type: 'slot',
+              attrs: { name: slot },
+              content: [{ type: 'paragraph', content: [] }],
+            }]
           }
 
           const command = chain().deleteRange(range).insertContentAt(range.from, value)
@@ -93,7 +99,13 @@ export const Element = Node.create<ElementOptions>({
         const value: Content = {
           type: 'element',
           attrs: { tag },
-          ...(slot ? { content: [{ type: 'slot', attrs: { name: slot }, content: [{ type: 'paragraph', content: [] }] }] } : {}),
+        }
+        if (slot) {
+          value.content = [{
+            type: 'slot',
+            attrs: { name: slot },
+            content: [{ type: 'paragraph', content: [] }],
+          }]
         }
 
         const command = chain().insertContentAt(from, value)

--- a/src/app/src/utils/tiptap/extensions/element.ts
+++ b/src/app/src/utils/tiptap/extensions/element.ts
@@ -75,13 +75,19 @@ export const Element = Node.create<ElementOptions>({
             value.content = [{
               type: 'slot',
               attrs: { name: slot },
-              content: [{ type: 'paragraph', content: [] }],
+              content: [{
+                type: 'paragraph',
+                content: [],
+              }],
             }]
           }
 
           const command = chain().deleteRange(range).insertContentAt(range.from, value)
           if (!slot) {
-            command.insertContentAt(range.from + 1, [{ type: 'paragraph', content: [] }])
+            command.insertContentAt(range.from + 1, [{
+              type: 'paragraph',
+              content: [],
+            }])
           }
           command.run()
         },
@@ -104,13 +110,19 @@ export const Element = Node.create<ElementOptions>({
           value.content = [{
             type: 'slot',
             attrs: { name: slot },
-            content: [{ type: 'paragraph', content: [] }],
+            content: [{
+              type: 'paragraph',
+              content: [],
+            }],
           }]
         }
 
         const command = chain().insertContentAt(from, value)
         if (!slot) {
-          command.insertContentAt(from + 1, [{ type: 'paragraph', content: [] }])
+          command.insertContentAt(from + 1, [{
+            type: 'paragraph',
+            content: [],
+          }])
         }
         return command.run()
       },

--- a/src/app/src/utils/tiptap/extensions/element.ts
+++ b/src/app/src/utils/tiptap/extensions/element.ts
@@ -5,6 +5,7 @@ import TiptapExtensionElement from '../../../components/tiptap/extension/TiptapE
 
 export interface ElementOptions {
   HTMLAttributes: Record<string, unknown>
+  resolveInitialSlot: (tag: string) => string | undefined
 }
 
 declare module '@tiptap/core' {
@@ -27,6 +28,7 @@ export const Element = Node.create<ElementOptions>({
     return {
       tag: 'div',
       HTMLAttributes: {},
+      resolveInitialSlot: () => 'default' as string | undefined,
     }
   },
 
@@ -63,23 +65,19 @@ export const Element = Node.create<ElementOptions>({
       new InputRule({
         find: /^::([a-z-]+)\s$/i,
         handler: ({ range, match, chain }) => {
+          const tag = match[1]!
+          const slot = this.options.resolveInitialSlot(tag)
           const value: Content = {
             type: 'element',
-            attrs: { tag: match[1] },
-            content: [{
-              type: 'slot',
-              attrs: { name: 'default' },
-              content: [{
-                type: 'paragraph',
-                content: [],
-              }],
-            }],
+            attrs: { tag },
+            ...(slot ? { content: [{ type: 'slot', attrs: { name: slot }, content: [{ type: 'paragraph', content: [] }] }] } : {}),
           }
 
-          chain()
-            .deleteRange(range)
-            .insertContentAt(range.from, value)
-            .run()
+          const command = chain().deleteRange(range).insertContentAt(range.from, value)
+          if (!slot) {
+            command.insertContentAt(range.from + 1, [{ type: 'paragraph', content: [] }])
+          }
+          command.run()
         },
       }),
     ]
@@ -95,17 +93,7 @@ export const Element = Node.create<ElementOptions>({
         const value: Content = {
           type: 'element',
           attrs: { tag },
-        }
-
-        if (slot) {
-          value.content = [{
-            type: 'slot',
-            attrs: { name: slot },
-            content: [{
-              type: 'paragraph',
-              content: [],
-            }],
-          }]
+          ...(slot ? { content: [{ type: 'slot', attrs: { name: slot }, content: [{ type: 'paragraph', content: [] }] }] } : {}),
         }
 
         const command = chain().insertContentAt(from, value)

--- a/src/app/src/utils/tiptap/handlers.ts
+++ b/src/app/src/utils/tiptap/handlers.ts
@@ -9,6 +9,13 @@ type Handler = {
 
 export const CALLOUT_TYPES = new Set(['callout', 'note', 'tip', 'warning', 'caution'])
 
+export function pickInitialSlot(slots: Array<{ name: string }> | undefined): string | undefined {
+  if (!slots?.length) return undefined
+  return slots
+    .slice()
+    .sort((a, b) => a.name === 'default' ? -1 : b.name === 'default' ? 1 : a.name.localeCompare(b.name))[0]!.name
+}
+
 export function imageHandler(): Handler {
   return {
     canExecute: (editor: Editor) => editor.can().insertContent({ type: 'image-picker' }),
@@ -41,10 +48,10 @@ export function calloutHandler(kind: string): Handler {
   }
 }
 
-export function componentHandler(kind: string): Handler {
+export function componentHandler(kind: string, initialSlot?: string): Handler {
   return {
-    canExecute: (editor: Editor) => editor.can().setElement(kind, 'default'),
-    execute: (editor: Editor) => editor.chain().focus().setElement(kind, 'default'),
+    canExecute: (editor: Editor) => editor.can().setElement(kind, initialSlot),
+    execute: (editor: Editor) => editor.chain().focus().setElement(kind, initialSlot),
     isActive: (editor: Editor) => editor.isActive(kind),
     isDisabled: undefined,
   }

--- a/src/app/test/unit/utils/tiptap/handlers.test.ts
+++ b/src/app/test/unit/utils/tiptap/handlers.test.ts
@@ -1,0 +1,27 @@
+import { expect, test, describe } from 'vitest'
+import { pickInitialSlot } from '../../../../src/utils/tiptap/handlers'
+
+describe('pickInitialSlot', () => {
+  test('returns undefined for no slots', () => {
+    expect(pickInitialSlot(undefined)).toBeUndefined()
+    expect(pickInitialSlot([])).toBeUndefined()
+  })
+
+  test('returns the only slot name when there is one', () => {
+    expect(pickInitialSlot([{ name: 'header' }])).toBe('header')
+  })
+
+  test('prefers default over other slots', () => {
+    expect(pickInitialSlot([{ name: 'footer' }, { name: 'default' }, { name: 'header' }])).toBe('default')
+  })
+
+  test('sorts non-default slots alphabetically when no default exists', () => {
+    expect(pickInitialSlot([{ name: 'footer' }, { name: 'body' }, { name: 'header' }])).toBe('body')
+  })
+
+  test('does not mutate the original array', () => {
+    const slots = [{ name: 'footer' }, { name: 'default' }]
+    pickInitialSlot(slots)
+    expect(slots[0]!.name).toBe('footer')
+  })
+})


### PR DESCRIPTION
When inserting a component — either via the slash-command menu or by typing `::component-name` — Studio was always creating a `slot` child node, even for components that have no slots. This meant slotless components ended up with an unexpected default slot in the TipTap tree.

The root cause was that both the `componentHandler` and the `::` input rule hardcoded `'default'` as the slot, with no check against the component's actual slot metadata from `nuxt-component-meta`.

I fixed this by:
- Extracting a `pickInitialSlot` helper that returns the first slot ordered by `default` first then alphabetically, or `undefined` for slotless components
- Using that in `useTiptapEditor` when building slash-menu handlers
- Adding a `resolveInitialSlot` option to the `Element` extension so the `::` input rule can do the same lookup — configured from `ContentEditorTipTap.vue` where Vue context is available
- Adding unit tests for the slot-picking logic

Resolves https://github.com/nuxt-content/nuxt-studio/issues/428

## Showcase

Before:

https://github.com/user-attachments/assets/cd410c3c-6b56-4698-ba4d-69c23cbf3c73


After: 

https://github.com/user-attachments/assets/03cb36e4-761f-414e-b0f7-06337d9090e7

