### PR TITLE
feat(tiptap): nested drag handles for blocks inside MDC component slots

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@octokit/types": "^16.0.0",
     "@release-it/conventional-changelog": "^11.0.1",
     "@tailwindcss/typography": "^0.5.20",
+    "@tiptap/extension-drag-handle": "3.26.0",
     "@tiptap/extension-emoji": "^3.26.0",
     "@tiptap/extension-table": "3.26.0",
     "@types/js-yaml": "^4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.20
         version: 0.5.20(tailwindcss@4.3.0)
+      '@tiptap/extension-drag-handle':
+        specifier: 3.26.0
+        version: 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/extension-collaboration@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(@tiptap/y-tiptap@3.0.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(@tiptap/y-tiptap@3.0.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))
       '@tiptap/extension-emoji':
         specifier: ^3.26.0
         version: 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(@tiptap/suggestion@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))(emojibase@17.0.0)

--- a/src/app/src/components/content/editor/ContentEditorTipTap.vue
+++ b/src/app/src/components/content/editor/ContentEditorTipTap.vue
@@ -63,9 +63,7 @@ const nestedDragHandle: NestedOptions = {
       evaluate: (ctx: RuleContext) => ctx.node.type.name === 'slot' ? 1000 : 0,
     },
     {
-      // Prevent the parent component from stealing the target when the cursor drifts into
-      // a slot's gutter. With the slot excluded, the component would otherwise win and the
-      // handle would jump away from the nested block.
+      // Keeps the handler at slot level by prevent the parent component to steal the target.
       id: 'excludeElementFromOwnSlot',
       evaluate: ({ node, depth, $pos }: RuleContext) =>
         node.type.name === 'element' && $pos.depth > depth && $pos.node(depth + 1)?.type.name === 'slot'

--- a/src/app/src/components/content/editor/ContentEditorTipTap.vue
+++ b/src/app/src/components/content/editor/ContentEditorTipTap.vue
@@ -28,7 +28,7 @@ import { CustomPlaceholder } from '../../../utils/tiptap/extensions/custom-place
 import TiptapTableGrips from '../../tiptap/TiptapTableGrips.vue'
 import { useTiptapEditor } from '../../../composables/useTiptapEditor'
 import { useTiptapEditorAI } from '../../../composables/useTiptapEditorAI'
-import type { RuleContext } from '@tiptap/extension-drag-handle'
+import type { NestedOptions, RuleContext } from '@tiptap/extension-drag-handle'
 
 const props = defineProps({
   draftItem: {
@@ -53,25 +53,36 @@ const {
   setSelectedNode,
 } = useTiptapEditor()
 
-const nestedDragHandle = {
-  rules: [{
-    id: 'excludeSlotNode',
-    evaluate: ({ node }: RuleContext) => node.type.name === 'slot' ? 1000 : 0,
-  }],
-}
-
-// mainAxis: 0 places the handle flush against the block's left edge, eliminating
-// the 8px gap that causes the handle to vanish before the cursor reaches it when
-// hovering over nested blocks inside slots.
-const dragHandleOptions = {
-  offset: ({ rects }: { rects: { reference: { height: number }, floating: { height: number } } }) => {
-    const blockHeight = rects.reference.height
-    const handleHeight = rects.floating.height
-    return {
-      mainAxis: 0,
-      alignmentAxis: blockHeight > 40 ? 0 : (blockHeight - handleHeight) / 2,
-    }
-  },
+const nestedDragHandle: NestedOptions = {
+  // edgeDetection: 'none' keeps the deepest block as the drag target even when the
+  // cursor is near its left edge. With the default ('left') edge detection, a block
+  // nested in a slot (depth ~3) gets a strength*depth = 500*3 penalty the moment the
+  // cursor enters the 12px edge zone where the handle sits — exceeding the 1000 base
+  // score, so the block is excluded and the handle jumps to the parent component,
+  // leaving the nested handle permanently unreachable.
+  edgeDetection: 'none',
+  rules: [
+    {
+      // The slot node is structural (selectable: false) and is never itself a drag target.
+      id: 'excludeSlotNode',
+      evaluate: (ctx: RuleContext) => ctx.node.type.name === 'slot' ? 1000 : 0,
+    },
+    {
+      // Keep the parent component (`element`) from becoming the target while the cursor
+      // is inside one of its slots. When the cursor drifts left of a nested block into
+      // the slot's padding, `posAtCoords` resolves to slot level; with the slot already
+      // excluded, the component would win and the handle would jump to it. Excluding the
+      // component here too leaves NO valid candidate — and the drag-handle plugin then
+      // early-returns (`if (!nodeData.resultElement) return`), leaving the handle parked
+      // on the last block instead of moving it. That's what makes the handle reachable:
+      // drifting into the gutter no longer steals the target.
+      id: 'excludeElementFromOwnSlot',
+      evaluate: ({ node, depth, $pos }: RuleContext) =>
+        node.type.name === 'element' && $pos.depth > depth && $pos.node(depth + 1)?.type.name === 'slot'
+          ? 1000
+          : 0,
+    },
+  ],
 }
 
 const {
@@ -239,7 +250,7 @@ watch(() => `${document.value?.id}-${props.draftItem.version}-${props.draftItem.
         v-slot="{ ui }"
         :editor="editor"
         :nested="nestedDragHandle"
-        :options="dragHandleOptions"
+        :options="{ strategy: 'fixed' }"
         @node-change="setSelectedNode"
       >
         <UDropdownMenu

--- a/src/app/src/components/content/editor/ContentEditorTipTap.vue
+++ b/src/app/src/components/content/editor/ContentEditorTipTap.vue
@@ -54,28 +54,20 @@ const {
 } = useTiptapEditor()
 
 const nestedDragHandle: NestedOptions = {
-  // edgeDetection: 'none' keeps the deepest block as the drag target even when the
-  // cursor is near its left edge. With the default ('left') edge detection, a block
-  // nested in a slot (depth ~3) gets a strength*depth = 500*3 penalty the moment the
-  // cursor enters the 12px edge zone where the handle sits — exceeding the 1000 base
-  // score, so the block is excluded and the handle jumps to the parent component,
-  // leaving the nested handle permanently unreachable.
+  // Default edge detection penalises deeply nested blocks enough to push them below the
+  // score threshold, making their handles unreachable. Disabling it keeps the deepest
+  // block as the target regardless of cursor proximity to the edge.
   edgeDetection: 'none',
   rules: [
     {
-      // The slot node is structural (selectable: false) and is never itself a drag target.
+      // slot is structural and never itself a drag target.
       id: 'excludeSlotNode',
       evaluate: (ctx: RuleContext) => ctx.node.type.name === 'slot' ? 1000 : 0,
     },
     {
-      // Keep the parent component (`element`) from becoming the target while the cursor
-      // is inside one of its slots. When the cursor drifts left of a nested block into
-      // the slot's padding, `posAtCoords` resolves to slot level; with the slot already
-      // excluded, the component would win and the handle would jump to it. Excluding the
-      // component here too leaves NO valid candidate — and the drag-handle plugin then
-      // early-returns (`if (!nodeData.resultElement) return`), leaving the handle parked
-      // on the last block instead of moving it. That's what makes the handle reachable:
-      // drifting into the gutter no longer steals the target.
+      // Prevent the parent component from stealing the target when the cursor drifts into
+      // a slot's gutter. With the slot excluded, the component would otherwise win and the
+      // handle would jump away from the nested block.
       id: 'excludeElementFromOwnSlot',
       evaluate: ({ node, depth, $pos }: RuleContext) =>
         node.type.name === 'element' && $pos.depth > depth && $pos.node(depth + 1)?.type.name === 'slot'

--- a/src/app/src/components/content/editor/ContentEditorTipTap.vue
+++ b/src/app/src/components/content/editor/ContentEditorTipTap.vue
@@ -54,9 +54,7 @@ const {
 } = useTiptapEditor()
 
 const nestedDragHandle: NestedOptions = {
-  // Default edge detection penalises deeply nested blocks enough to push them below the
-  // score threshold, making their handles unreachable. Disabling it keeps the deepest
-  // block as the target regardless of cursor proximity to the edge.
+  // Default edge detection makes handles unreachable for D&D.
   edgeDetection: 'none',
   rules: [
     {

--- a/src/app/src/components/content/editor/ContentEditorTipTap.vue
+++ b/src/app/src/components/content/editor/ContentEditorTipTap.vue
@@ -28,6 +28,7 @@ import { CustomPlaceholder } from '../../../utils/tiptap/extensions/custom-place
 import TiptapTableGrips from '../../tiptap/TiptapTableGrips.vue'
 import { useTiptapEditor } from '../../../composables/useTiptapEditor'
 import { useTiptapEditorAI } from '../../../composables/useTiptapEditorAI'
+import type { RuleContext } from '@tiptap/extension-drag-handle'
 
 const props = defineProps({
   draftItem: {
@@ -51,6 +52,27 @@ const {
   dragHandleItems,
   setSelectedNode,
 } = useTiptapEditor()
+
+const nestedDragHandle = {
+  rules: [{
+    id: 'excludeSlotNode',
+    evaluate: ({ node }: RuleContext) => node.type.name === 'slot' ? 1000 : 0,
+  }],
+}
+
+// mainAxis: 0 places the handle flush against the block's left edge, eliminating
+// the 8px gap that causes the handle to vanish before the cursor reaches it when
+// hovering over nested blocks inside slots.
+const dragHandleOptions = {
+  offset: ({ rects }: { rects: { reference: { height: number }, floating: { height: number } } }) => {
+    const blockHeight = rects.reference.height
+    const handleHeight = rects.floating.height
+    return {
+      mainAxis: 0,
+      alignmentAxis: blockHeight > 40 ? 0 : (blockHeight - handleHeight) / 2,
+    }
+  },
+}
 
 const {
   MAX_AI_SELECTION_LENGTH,
@@ -216,6 +238,8 @@ watch(() => `${document.value?.id}-${props.draftItem.version}-${props.draftItem.
       <UEditorDragHandle
         v-slot="{ ui }"
         :editor="editor"
+        :nested="nestedDragHandle"
+        :options="dragHandleOptions"
         @node-change="setSelectedNode"
       >
         <UDropdownMenu


### PR DESCRIPTION
Resolves #243

## Summary

- Enables TipTap's nested drag handle support (`@tiptap/extension-drag-handle` v3.17+) so blocks inside MDC component slots finally get drag handles
- Adds `@tiptap/extension-drag-handle` as a direct dependency (was previously transitive via `@tiptap/extension-drag-handle-vue-3`)
- Adds a custom rule to exclude the `slot` node itself from being a drag target — users should drag blocks *inside* a slot, not the slot container
- Makes the nested handle actually **reachable**: `edgeDetection: 'none'` (stop parent-promotion near the block edge), a rule that excludes the parent component while the cursor is inside its own slot (so drifting into the slot gutter no longer steals the target), and floating-ui `strategy: 'fixed'` (fixes positioning lag when the editor is scrolled)

## Test plan

- [x] Open a file with an MDC component that has slots (e.g. a callout or card component)
- [x] Hover over a paragraph/heading inside a slot — confirm the drag handle appears
- [x] Drag a block to reorder it within the slot
- [x] Confirm the context menu (move up/down, insert before/after, delete, etc.) works on nested nodes
- [x] Confirm top-level blocks outside slots still show drag handles as before
- [x] Confirm hovering the slot container itself does NOT show a drag handle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
