### PR TITLE
fix(tiptap): keep dragged blocks out of component interiors

### DIFF
--- a/src/app/src/utils/tiptap/extensions/slot-drop-guard.ts
+++ b/src/app/src/utils/tiptap/extensions/slot-drop-guard.ts
@@ -3,8 +3,7 @@ import type { Node as PMNode, Slice } from '@tiptap/pm/model'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { dropPoint } from '@tiptap/pm/transform'
 
-// A component (`element`) accepts `block*`, so a drop can land a block directly inside
-// it instead of in a slot.
+// `element` accepts `block*`, so drops can bypass slots and land directly inside the component.
 export function dropWouldLandInElement(doc: PMNode, coordPos: number, slice: Slice): boolean {
   if (!slice.content.size) {
     return false

--- a/src/app/src/utils/tiptap/extensions/slot-drop-guard.ts
+++ b/src/app/src/utils/tiptap/extensions/slot-drop-guard.ts
@@ -1,0 +1,32 @@
+import { Extension } from '@tiptap/core'
+import type { Node as PMNode, Slice } from '@tiptap/pm/model'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { dropPoint } from '@tiptap/pm/transform'
+
+// A component (`element`) accepts `block*`, so a drop can land a block directly inside
+// it instead of in a slot. This detects that so the drop can be cancelled.
+export function dropWouldLandInElement(doc: PMNode, coordPos: number, slice: Slice): boolean {
+  if (!slice.content.size) {
+    return false
+  }
+  const $pos = doc.resolve(dropPoint(doc, coordPos, slice) ?? coordPos)
+  return $pos.parent.type.name === 'element'
+}
+
+export const SlotDropGuard = Extension.create({
+  name: 'slotDropGuard',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('slotDropGuard'),
+        props: {
+          handleDrop(view, event, slice) {
+            const coords = view.posAtCoords({ left: event.clientX, top: event.clientY })
+            return coords ? dropWouldLandInElement(view.state.doc, coords.pos, slice) : false
+          },
+        },
+      }),
+    ]
+  },
+})

--- a/src/app/src/utils/tiptap/extensions/slot-drop-guard.ts
+++ b/src/app/src/utils/tiptap/extensions/slot-drop-guard.ts
@@ -4,7 +4,7 @@ import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { dropPoint } from '@tiptap/pm/transform'
 
 // A component (`element`) accepts `block*`, so a drop can land a block directly inside
-// it instead of in a slot. This detects that so the drop can be cancelled.
+// it instead of in a slot.
 export function dropWouldLandInElement(doc: PMNode, coordPos: number, slice: Slice): boolean {
   if (!slice.content.size) {
     return false

--- a/src/app/src/utils/tiptap/studio-extensions.ts
+++ b/src/app/src/utils/tiptap/studio-extensions.ts
@@ -10,6 +10,7 @@ import { Image } from './extensions/image'
 import { ImagePicker } from './extensions/image-picker'
 import { InlineElement } from './extensions/inline-element'
 import { Slot } from './extensions/slot'
+import { SlotDropGuard } from './extensions/slot-drop-guard'
 import { SpanStyle } from './extensions/span-style'
 import { Table, TableCell, TableHeader, TableRow } from './extensions/table'
 import { Video } from './extensions/video'
@@ -47,6 +48,7 @@ export function createStudioExtensions({
     InlineElement,
     SpanStyle,
     Slot,
+    SlotDropGuard,
     CodeBlock,
     Emoji,
     Binding,

--- a/src/app/test/unit/utils/tiptap/extensions/slot-drop-guard.test.ts
+++ b/src/app/test/unit/utils/tiptap/extensions/slot-drop-guard.test.ts
@@ -1,0 +1,82 @@
+import type { JSONContent } from '@tiptap/core'
+import { describe, test, expect, afterEach } from 'vitest'
+import type { Editor } from '@tiptap/core'
+import { Fragment, Slice } from '@tiptap/pm/model'
+import { createEditor } from '../../../../utils/editor'
+import { dropWouldLandInElement } from '../../../../../src/utils/tiptap/extensions/slot-drop-guard'
+
+function posInside(editor: Editor, text: string): number {
+  let pos = -1
+  editor.state.doc.descendants((node, nodePos) => {
+    if (pos === -1 && node.isTextblock && node.textContent === text) {
+      pos = nodePos + 1
+      return false
+    }
+  })
+  return pos
+}
+
+function paragraphSlice(editor: Editor): Slice {
+  const paragraph = editor.schema.nodes.paragraph.create(null, editor.schema.text('dropped'))
+  return new Slice(Fragment.from(paragraph), 0, 0)
+}
+
+describe('slot-drop-guard › dropWouldLandInElement', () => {
+  let editor: Editor | undefined
+
+  afterEach(() => {
+    editor?.destroy()
+    editor = undefined
+  })
+
+  // doc
+  // ├─ element (card)
+  // │  ├─ slot (default) → paragraph "in-slot"
+  // │  └─ paragraph "loose-in-element"   (direct child of the element, like exit-slot leaves)
+  // └─ paragraph "top-level"
+  function buildEditor() {
+    const json: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'element',
+          attrs: { tag: 'card', props: {} },
+          content: [
+            {
+              type: 'slot',
+              attrs: { name: 'default', props: {} },
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'in-slot' }] }],
+            },
+            { type: 'paragraph', content: [{ type: 'text', text: 'loose-in-element' }] },
+          ],
+        },
+        { type: 'paragraph', content: [{ type: 'text', text: 'top-level' }] },
+      ],
+    }
+    return createEditor(json)
+  }
+
+  test('cancels a drop that lands directly inside a component element', () => {
+    editor = buildEditor()
+    const pos = posInside(editor, 'loose-in-element')
+    expect(dropWouldLandInElement(editor.state.doc, pos, paragraphSlice(editor))).toBe(true)
+  })
+
+  test('allows a drop inside a slot', () => {
+    editor = buildEditor()
+    const pos = posInside(editor, 'in-slot')
+    expect(dropWouldLandInElement(editor.state.doc, pos, paragraphSlice(editor))).toBe(false)
+  })
+
+  test('allows a drop at the document level', () => {
+    editor = buildEditor()
+    const pos = posInside(editor, 'top-level')
+    expect(dropWouldLandInElement(editor.state.doc, pos, paragraphSlice(editor))).toBe(false)
+  })
+
+  test('ignores an empty slice', () => {
+    editor = buildEditor()
+    const pos = posInside(editor, 'loose-in-element')
+    expect(dropWouldLandInElement(editor.state.doc, pos, Slice.empty)).toBe(false)
+  })
+})

--- a/src/app/test/unit/utils/tiptap/extensions/slot-drop-guard.test.ts
+++ b/src/app/test/unit/utils/tiptap/extensions/slot-drop-guard.test.ts
@@ -1,6 +1,5 @@
-import type { JSONContent } from '@tiptap/core'
+import type { JSONContent, Editor } from '@tiptap/core'
 import { describe, test, expect, afterEach } from 'vitest'
-import type { Editor } from '@tiptap/core'
 import { Fragment, Slice } from '@tiptap/pm/model'
 import { createEditor } from '../../../../utils/editor'
 import { dropWouldLandInElement } from '../../../../../src/utils/tiptap/extensions/slot-drop-guard'
@@ -29,11 +28,6 @@ describe('slot-drop-guard › dropWouldLandInElement', () => {
     editor = undefined
   })
 
-  // doc
-  // ├─ element (card)
-  // │  ├─ slot (default) → paragraph "in-slot"
-  // │  └─ paragraph "loose-in-element"   (direct child of the element, like exit-slot leaves)
-  // └─ paragraph "top-level"
   function buildEditor() {
     const json: JSONContent = {
       type: 'doc',

--- a/src/app/test/utils/editor.ts
+++ b/src/app/test/utils/editor.ts
@@ -18,12 +18,16 @@ const STUDIO_EDITOR_EXTENSIONS = [
   ...createStudioExtensions(),
 ]
 
-// Applies ProseMirror's mark rank-sort and dedup — the same pass the real editor runs.
-export function roundTripThroughEditor(json: JSONContent): JSONContent {
-  const editor = new Editor({
+export function createEditor(json: JSONContent): Editor {
+  return new Editor({
     extensions: STUDIO_EDITOR_EXTENSIONS,
     content: json,
   })
+}
+
+// Applies ProseMirror's mark rank-sort and dedup — the same pass the real editor runs.
+export function roundTripThroughEditor(json: JSONContent): JSONContent {
+  const editor = createEditor(json)
   const out = editor.getJSON()
   editor.destroy()
   return out


### PR DESCRIPTION
## Summary

A block dragged in the editor could be dropped **directly inside a component** (`element`), above or below its `slot`, leaving an orphan block where only slot content belongs. ProseMirror's native drop uses `dropPoint`, and because `element` content is `block*`, "inside the element" is a schema-valid drop target.

This adds a `SlotDropGuard` extension whose `handleDrop` **cancels** a drop when the computed drop position resolves to a component `element` container — the dragged block stays where it was and the user re-aims at a slot. Drops inside a slot, or at the document level, are unaffected.

We can't fix this via the schema: `element` must stay `block*` because the slot's `exitEmptyTextblockFromSlot` (double-Enter) command places a block directly after the slot.

Follow-up to #243 (the nested drag handle feature, enabled in #490). Independent of #490 — branched off `main`.

## Examples

Before:

https://github.com/user-attachments/assets/77b25791-bb9c-4d85-a8f7-588467f563d3


After:

https://github.com/user-attachments/assets/2acf6d02-af64-4da7-b9b8-8e3620153e05


## Test plan

- [x] Unit (`slot-drop-guard.test.ts`): `dropWouldLandInElement` → `true` for an element-interior drop position, `false` for in-slot, doc-level, and empty slices.
- [x] Drag a top-level block onto a component's body (not its slot) → drop is cancelled, block stays put.
- [x] Drag a block into a slot → works.
- [x] Drag a block to the top level between components → works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
