### PR TITLE
fix(tiptap): fix slot rename crash, duplicate slots in dropdown, and click-through on slot selector

### DIFF
--- a/src/app/src/components/tiptap/extension/TiptapExtensionSlot.vue
+++ b/src/app/src/components/tiptap/extension/TiptapExtensionSlot.vue
@@ -8,7 +8,6 @@ const nodeProps = defineProps(nodeViewProps)
 
 const { host } = useStudio()
 
-const isHovered = ref(false)
 const isEditable = ref(true) // TODO: Connect to editor state
 
 const slotName = computed({
@@ -32,10 +31,10 @@ const slots = computed(() => componentMeta.value?.meta.slots || [])
 const showSlotSelection = computed(() => slots.value.length > 1)
 const usedSlots = computed(() =>
   (parent.value?.content?.content as ProseMirrorNode[] || [])
-    .map(s => s.attrs.name as string),
+    .map(slot => slot.attrs.name as string),
 )
 // All declared slots minus those already used by siblings (including this slot itself)
-const availableSlots = computed(() => slots.value.map(s => s.name).filter(n => !usedSlots.value.includes(n)))
+const availableSlots = computed(() => slots.value.map(slot => slot.name).filter(name => !usedSlots.value.includes(name)))
 const isLastRemainingSlot = computed(() => parent.value?.childCount === 1)
 
 function deleteSlot() {
@@ -54,9 +53,7 @@ function deleteSlot() {
     <div class="my-2">
       <div
         v-if="showSlotSelection"
-        class="flex items-center gap-2 mb-2 group"
-        @mouseenter="isHovered = true"
-        @mouseleave="isHovered = false"
+        class="flex items-center gap-2 mb-2"
       >
         <USelectMenu
           v-model="slotName"

--- a/src/app/src/components/tiptap/extension/TiptapExtensionSlot.vue
+++ b/src/app/src/components/tiptap/extension/TiptapExtensionSlot.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { nodeViewProps, NodeViewWrapper, NodeViewContent } from '@tiptap/vue-3'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { useStudio } from '../../../composables/useStudio'
 
 const nodeProps = defineProps(nodeViewProps)
@@ -29,7 +30,12 @@ const parent = computed(() => {
 const componentMeta = computed(() => host.meta.editor.components.get().find(c => c.name === parent.value?.attrs.tag))
 const slots = computed(() => componentMeta.value?.meta.slots || [])
 const showSlotSelection = computed(() => slots.value.length > 1)
-const availableSlots = computed(() => slots.value.map(s => s.name))
+const usedSlots = computed(() =>
+  (parent.value?.content?.content as ProseMirrorNode[] || [])
+    .map(s => s.attrs.name as string),
+)
+// All declared slots minus those already used by siblings (including this slot itself)
+const availableSlots = computed(() => slots.value.map(s => s.name).filter(n => !usedSlots.value.includes(n)))
 const isLastRemainingSlot = computed(() => parent.value?.childCount === 1)
 
 function deleteSlot() {
@@ -61,6 +67,7 @@ function deleteSlot() {
           size="xs"
           :ui="{
             base: 'font-mono text-xs text-muted hover:text-default uppercase cursor-pointer ring-0',
+            content: 'z-[9999]',
           }"
         >
           <template #leading>

--- a/src/app/src/utils/tiptap/comarkToTiptap.ts
+++ b/src/app/src/utils/tiptap/comarkToTiptap.ts
@@ -307,6 +307,11 @@ function createTemplateNode(node: ComarkElement): JSONContent {
   if (children.length > 0 && isInlineFirstChild) {
     children = [['p', {}, ...children] as ComarkElement]
   }
+  else if (children.length === 0) {
+    // TipTap slot requires block+ content; an empty slot would be schema-invalid
+    // and crash setNodeMarkup on any later updateAttributes (e.g. renaming the slot).
+    children = [['p', {}] as ComarkElement]
+  }
 
   const processedNode: ComarkElement = [getTag(node), cleanAttrs, ...children]
   return createTipTapNode(processedNode, 'slot', { attrs: { name } })


### PR DESCRIPTION
While testing MDC components with multiple named slots, I ran into a few separate issues with the slot editing UI that all interact with each other in confusing ways. Here's what I found and how I fixed them.

## Issues

### 1. Renaming a slot crashes the editor when the slot is empty

If you open a file that has an empty named slot (e.g. `#footer` with no content), trying to change the slot name via the dropdown throws a `RangeError: Invalid content for node type slot` and the rename silently fails.

The root cause is in `createTemplateNode` in `comarkToTiptap.ts`. When parsing a slot with no children, it builds a TipTap `slot` node with an empty content array. But the slot node schema declares `content: 'block+'` — at least one block child is required. The node gets created and renders fine, but the moment you call `updateAttributes` (which is what the rename dropdown does), ProseMirror re-validates the node's content and throws.

The fix is to inject an empty paragraph when the slot has no children, which is exactly what the `addSlot` function in `TiptapExtensionElement.vue` already does when creating new slots programmatically. The round-trip is clean — `tiptapToComark` unwraps single empty paragraphs back to nothing, so no content is affected.

### 2. The slot rename dropdown lets you pick a name already in use

The dropdown showed the full list of slots declared by the component, with no filtering for names already used by sibling slots. This made it possible to end up with two `#header` slots in the same component, which then causes all sorts of confusion.

The pattern for filtering already-used slots already exists in `TiptapExtensionElement.vue` — it's how the "add slot" button decides which slot to add next. I just applied the same `usedSlots` computed to the rename dropdown in `TiptapExtensionSlot.vue`, so the dropdown only shows slots you can actually switch to. The current slot's own name is also excluded since there's no point offering "stay as header."

### 3. Clicking items in the slot dropdown doesn't work

Keyboard navigation through the dropdown worked fine, but clicking items did nothing. After some debugging, the issue turned out to be z-index: the dropdown was rendering behind other Studio UI elements. The `USelectMenu` teleports its content to `<body>` via Reka's `ComboboxPortal`, but without an explicit z-index the dropdown ended up behind other layered elements in the editor layout.

Fixed by adding `content: 'z-[9999]'` to the `USelectMenu`'s `:ui` prop, which targets the teleported dropdown container.