### PR TITLE
fix: SVG (and other binary files with + in MIME type) corrupted when publishing to GitHub

### DIFF
--- a/src/app/src/composables/useDraftBase.ts
+++ b/src/app/src/composables/useDraftBase.ts
@@ -246,10 +246,6 @@ export function useDraftBase<T extends DatabaseItem | MediaItem>(
   }
 
   async function getStatus(modified: BaseItem, original: BaseItem, opts?: { formattingApplied?: boolean }): Promise<DraftStatus> {
-    if (devMode.value) {
-      return DraftStatus.Pristine
-    }
-
     if (!modified && !original) {
       throw new Error('Unconsistent state: both modified and original are undefined')
     }
@@ -260,6 +256,10 @@ export function useDraftBase<T extends DatabaseItem | MediaItem>(
 
     if (!original || original.id !== modified.id) {
       return DraftStatus.Created
+    }
+
+    if (devMode.value) {
+      return DraftStatus.Pristine
     }
 
     // User explicitly accepted comark's formatting via the banner

--- a/src/app/src/composables/useDraftMedias.ts
+++ b/src/app/src/composables/useDraftMedias.ts
@@ -157,7 +157,7 @@ export const useDraftMedias = createSharedComposable((host: StudioHost, gitProvi
       }
 
       const raw = draftItem.modified?.raw as string | undefined
-      const content = raw ? raw.replace(/^data:\w+\/\w+;base64,/, '') : ''
+      const content = raw ? raw.replace(/^data:[^;]+;base64,/, '') : ''
       files.push({ path: joinURL('public', draftItem.fsPath), content, status: draftItem.status, encoding: 'base64' })
     }
 

--- a/src/module/src/runtime/server/routes/ipx/[...path].ts
+++ b/src/module/src/runtime/server/routes/ipx/[...path].ts
@@ -1,6 +1,6 @@
 import { createError, eventHandler, getRequestURL, setResponseHeader } from 'h3'
 import { requireStudioAuth } from '../../utils/auth'
-import { DAY_IN_SECONDS, IPX_PREFIX, getContentTypeFromPath, getIpx, getOriginalImage, parseIpxPath, requireAllowedDomain } from '../../utils/media/ipx'
+import { DAY_IN_SECONDS, IPX_PREFIX, getContentTypeFromPath, getIpx, getOriginalImage, isIpxProcessable, parseIpxPath, requireAllowedDomain } from '../../utils/media/ipx'
 
 /**
  * Serve optimized thumbnails for Studio media picker using IPX.
@@ -24,6 +24,19 @@ export default eventHandler(async (event) => {
 
   const domain = requireAllowedDomain(parsed.id)
   const originUrl = url.origin
+
+  if (!isIpxProcessable(parsed.id)) {
+    const originalData = await getOriginalImage(parsed.id, originUrl)
+    if (!originalData) {
+      throw createError({ message: 'Image not found', statusCode: 404 })
+    }
+    const contentType = getContentTypeFromPath(parsed.id)
+    if (contentType) {
+      setResponseHeader(event, 'content-type', contentType)
+    }
+    setResponseHeader(event, 'cache-control', `public, max-age=${DAY_IN_SECONDS}, s-maxage=${DAY_IN_SECONDS}`)
+    return originalData
+  }
 
   const ipx = await getIpx(domain, originUrl)
   let data: Buffer | string

--- a/src/module/src/runtime/server/utils/media/ipx.ts
+++ b/src/module/src/runtime/server/utils/media/ipx.ts
@@ -144,8 +144,6 @@ export async function getIpx(domain?: string, originUrl?: string): Promise<IpxHa
   return cachedIpx
 }
 
-// Extensions that sharp can process as raster input. Anything outside this set
-// (e.g. SVG, ICO) is served raw to avoid unwanted format conversion.
 const RASTER_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.avif', '.gif'])
 
 export function isIpxProcessable(id: string): boolean {

--- a/src/module/src/runtime/server/utils/media/ipx.ts
+++ b/src/module/src/runtime/server/utils/media/ipx.ts
@@ -144,6 +144,14 @@ export async function getIpx(domain?: string, originUrl?: string): Promise<IpxHa
   return cachedIpx
 }
 
+// Extensions that sharp can process as raster input. Anything outside this set
+// (e.g. SVG, ICO) is served raw to avoid unwanted format conversion.
+const RASTER_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.avif', '.gif'])
+
+export function isIpxProcessable(id: string): boolean {
+  return RASTER_EXTENSIONS.has(extname(id).toLowerCase())
+}
+
 export function getContentTypeFromPath(path: string) {
   const extension = extname(path).toLowerCase()
 


### PR DESCRIPTION
Three bugs, all around SVG/media handling:

**1. Corrupted file on publish** — `\w+` in the data URL prefix regex doesn't match `+`, so `image/svg+xml` never stripped, and the full data URL was committed to git as base64.

**2. SVG rasterized in preview** — the IPX endpoint passes everything through sharp, which silently converts SVGs to PNG. Fixed with an allowlist of raster extensions (`RASTER_EXTENSIONS`) that are the only ones sent to sharp; everything else is served raw.

**3. Preview broken after first load in dev mode** — `getStatus()` returned `Pristine` unconditionally in dev mode, including for new uploads with no original. `load()` purges Pristine entries, so the service worker lost the IndexedDB entry after the first hook cycle. Fixed by moving the `!original → Created` check before the dev-mode shortcut.