### PR TITLE
fix(legacy): preserve boolean binding props through MDC→Comark bridge

### DIFF
--- a/src/module/src/runtime/utils/document/legacy.ts
+++ b/src/module/src/runtime/utils/document/legacy.ts
@@ -312,11 +312,8 @@ function normalizeMdcChildren(children: MDCNode[]): MDCNode[] {
 function propsMDCToComark(tag: string, props: Record<string, unknown>): Record<string, unknown> {
   let next: Record<string, unknown> = props
 
-  // @nuxtjs/mdc serializes non-primitive YAML block props (arrays, objects) as
-  // Vue binding syntax: key ":authorsOne" + JSON-stringified value. Unwrap these
-  // back to plain keys with their real JavaScript values.
-  // Booleans stay as ':key': 'true'/'false' — comarkAttributes needs the ':' prefix
-  // to emit the shorthand form (e.g. `reverse`) instead of `reverse="true"`.
+  // Unwrap @nuxtjs/mdc's ':key' + JSON-string encoding for arrays/objects to plain values.
+  // Booleans keep the ':' prefix — comarkAttributes needs it to emit `key` not `key="true"`.
   const unbound: Record<string, unknown> = {}
   for (const [rawKey, value] of Object.entries(next)) {
     if (rawKey.startsWith(':') && typeof value === 'string') {

--- a/src/module/src/runtime/utils/document/legacy.ts
+++ b/src/module/src/runtime/utils/document/legacy.ts
@@ -315,11 +315,19 @@ function propsMDCToComark(tag: string, props: Record<string, unknown>): Record<s
   // @nuxtjs/mdc serializes non-primitive YAML block props (arrays, objects) as
   // Vue binding syntax: key ":authorsOne" + JSON-stringified value. Unwrap these
   // back to plain keys with their real JavaScript values.
+  // Booleans stay as ':key': 'true'/'false' — comarkAttributes needs the ':' prefix
+  // to emit the shorthand form (e.g. `reverse`) instead of `reverse="true"`.
   const unbound: Record<string, unknown> = {}
   for (const [rawKey, value] of Object.entries(next)) {
     if (rawKey.startsWith(':') && typeof value === 'string') {
       try {
-        unbound[rawKey.slice(1)] = JSON.parse(value)
+        const parsed = JSON.parse(value)
+        if (typeof parsed === 'boolean') {
+          unbound[rawKey] = value
+        }
+        else {
+          unbound[rawKey.slice(1)] = parsed
+        }
       }
       catch {
         unbound[rawKey] = value

--- a/src/module/test/utils/legacy.test.ts
+++ b/src/module/test/utils/legacy.test.ts
@@ -834,6 +834,37 @@ describe('comark → mdc reverse helpers (used at DB write boundary)', () => {
     expect(markdown).not.toContain('[object Object]')
   })
 
+  it('preserves boolean binding props (:key: "true"/"false") without stripping the colon prefix', async () => {
+    const mdcBody: MDCRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tag: 'u-page-section',
+          props: {
+            'orientation': 'horizontal',
+            ':reverse': 'true',
+            ':square': 'false',
+          },
+          children: [],
+        } as unknown,
+      ],
+    } as MDCRoot
+
+    const tree = comarkTreeFromLegacyDocument(legacyDocument(mdcBody))!
+    const [, attrs] = tree.nodes[0] as [string, Record<string, unknown>]
+
+    expect(attrs[':reverse']).toBe('true')
+    expect(attrs[':square']).toBe('false')
+    expect('reverse' in attrs).toBe(false)
+    expect('square' in attrs).toBe(false)
+
+    const markdown = await renderMarkdown(tree)
+    expect(markdown).toContain('reverse')
+    expect(markdown).not.toContain('reverse="true"')
+    expect(markdown).toContain(':square="false"')
+  })
+
   it('writes back `class` strings as `className` arrays', () => {
     const tree: ComarkTree = {
       nodes: [['span', { class: 'text-primary font-bold' }, 'Nuxt']],


### PR DESCRIPTION
- `propsMDCToComark` was JSON-parsing all `':key': 'string'` bindings and stripping the `:` prefix. For booleans, `JSON.parse('true')` succeeds, so `':reverse': 'true'` became `{ reverse: true }`.
- `comarkAttributes` only recognises the shorthand (no-value) form for `':key': 'true'` pairs. Without the `:` prefix, `{ reverse: true }` rendered as `reverse="true"` instead of `reverse`.
- This triggered the formatting banner on every file with a valueless boolean prop (e.g. `{reverse}`).

**Root cause commit**: `0262b94` — the `unbound` loop was scoped to unwrap arrays/objects but over-eagerly processed booleans too.

**Fix**: boolean bindings skip the unwrapping and keep their `:` prefix intact.