### PR TITLE
fix(tiptap): preserve named slots in comarkToTiptap/tiptapToComark round-trip

### DIFF
--- a/src/app/src/app.vue
+++ b/src/app/src/app.vue
@@ -68,12 +68,9 @@ host.on.mounted(async () => {
 
   // If no location set, it means first time opening the app
   if (!location.value || location.value.active) {
-    // Ensure drafts are loaded before opening so selectByFsPath finds
-    // the IndexedDB draft rather than falling back to stale DB content.
-    if (!isReady.value) {
-      await new Promise<void>(resolve => watch(isReady, () => resolve(), { once: true }))
-    }
-    await open()
+    setTimeout(async () => {
+      await open()
+    }, 100)
   }
 })
 

--- a/src/app/src/app.vue
+++ b/src/app/src/app.vue
@@ -68,9 +68,12 @@ host.on.mounted(async () => {
 
   // If no location set, it means first time opening the app
   if (!location.value || location.value.active) {
-    setTimeout(async () => {
-      await open()
-    }, 100)
+    // Ensure drafts are loaded before opening so selectByFsPath finds
+    // the IndexedDB draft rather than falling back to stale DB content.
+    if (!isReady.value) {
+      await new Promise<void>(resolve => watch(isReady, () => resolve(), { once: true }))
+    }
+    await open()
   }
 })
 

--- a/src/app/src/utils/tiptap/comarkToTiptap.ts
+++ b/src/app/src/utils/tiptap/comarkToTiptap.ts
@@ -435,8 +435,17 @@ function createElementNode(node: ComarkElement, type: string, hasNuxtUI = false)
   let processedNode = node
   const nodeChildren = getChildren(processedNode)
   if (nodeChildren.length > 0 && typeof nodeChildren[0] === 'string') {
+    const isTemplate = (child: ComarkNode): boolean =>
+      isElement(child) && getTag(child as ComarkElement) === 'template'
+    const nonTemplateChildren = nodeChildren.filter(c => !isTemplate(c))
+    const templateChildren = nodeChildren.filter(isTemplate)
     const originalAttrs = getAttrs(processedNode)
-    processedNode = [type, { ...originalAttrs, __tiptapWrap: true }, ['p', {}, ...nodeChildren] as ComarkElement] as ComarkElement
+    processedNode = [
+      type,
+      { ...originalAttrs, __tiptapWrap: true },
+      ['p', {}, ...nonTemplateChildren] as ComarkElement,
+      ...templateChildren,
+    ] as ComarkElement
   }
 
   const slotWrapped = wrapChildrenWithinSlot(getChildren(processedNode))

--- a/src/app/src/utils/tiptap/tiptapToComark.ts
+++ b/src/app/src/utils/tiptap/tiptapToComark.ts
@@ -197,9 +197,9 @@ function createElement(node: JSONContent, tag?: string, extra: unknown = {}): Co
   // Unwrap TipTap wrapper
   // If text was enclosed in a paragraph manually in 'comarkToTiptap' for TipTap purpose, remove it in comark
   if (node.attrs?.props?.__tiptapWrap) {
-    if (children.length === 1 && children[0]?.type === 'slot') {
-      const slot = children[0]
-      slot.content = unwrapParagraph(slot.content || [])
+    const defaultSlot = children.find(c => c?.type === 'slot' && c.attrs?.name === 'default')
+    if (defaultSlot) {
+      defaultSlot.content = unwrapParagraph(defaultSlot.content || [])
     }
     delete node.attrs.props.__tiptapWrap
   }

--- a/src/app/test/integration/tiptap.test.ts
+++ b/src/app/test/integration/tiptap.test.ts
@@ -635,6 +635,55 @@ Hello
     expect(outputContent).toBe(`${inputContent}\n`)
   })
 
+  test('block element with raw-string default content alongside a named slot', async () => {
+    // comarkToTiptap's __tiptapWrap path fires when an element's first child is a raw string
+    // (comark auto-unwrap for single-line inline content). When template siblings exist
+    // alongside that string the old code buried them all inside the wrapper <p>, losing the
+    // named slots entirely. Both createElementNode (comarkToTiptap) and the __tiptapWrap
+    // paragraph-unwrap branch (tiptapToComark) must handle the multi-slot case correctly.
+    const comarkTree: ComarkTree = {
+      nodes: [
+        ['block-element', {}, 'Hello', ['template', { name: 'custom' }, 'World']],
+      ],
+      frontmatter: {},
+    }
+
+    const expectedTiptapJSON: JSONContent = {
+      type: 'doc',
+      content: [
+        { type: 'frontmatter', attrs: { frontmatter: {} } },
+        {
+          type: 'element',
+          attrs: { tag: 'block-element' },
+          content: [
+            {
+              type: 'slot',
+              attrs: { name: 'default' },
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello' }] }],
+            },
+            {
+              type: 'slot',
+              attrs: { name: 'custom' },
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'World' }] }],
+            },
+          ],
+        },
+      ],
+    }
+
+    const tiptapJSON: JSONContent = comarkToTiptap(comarkTree)
+    expect(tiptapJSON).toMatchObject(expectedTiptapJSON)
+
+    // After the editor round-trip, tiptapToComark must unwrap the __tiptapWrap paragraph
+    // from the default slot even when named siblings are present — restoring the original
+    // raw-string structure.
+    const editorJSON = roundTripThroughEditor(tiptapJSON)
+    const rtComarkTree = await tiptapToComark(editorJSON)
+    expect(rtComarkTree.nodes).toMatchObject([
+      ['block-element', {}, 'Hello', ['template', { name: 'custom' }, 'World']],
+    ])
+  })
+
   test('block element with unwrap="p" on slot names', async () => {
     const inputContent = `::u-page-feature
 #title{unwrap="p"}


### PR DESCRIPTION
When a component's default content is written as a short inline string — the kind comark auto-unwraps rather than wrapping in an explicit paragraph — we temporarily box it into a `<p>` on the way into TipTap so the editor has something to anchor to. The bug was that this boxing step grabbed *all* of the component's children at once, including any named slots that came after the inline string. Those slots got buried inside the paragraph and never made it into the editor document.

On the way back out, there was a matching assumption: if we needed to unbox that paragraph, there could only be one slot to worry about. So when named slots *were* present (having somehow survived), the unbox logic wouldn't fire for them either.

The fix is conceptually simple: keep the two concerns separate. Box only the inline default content; leave the named slots alone. Then when unboxing on the way out, look for the default slot specifically rather than assuming it's the only one.