### PR TITLE
fix(app): await isReady before open() to avoid race with draft load

### DIFF
--- a/src/app/src/app.vue
+++ b/src/app/src/app.vue
@@ -68,9 +68,10 @@ host.on.mounted(async () => {
 
   // If no location set, it means first time opening the app
   if (!location.value || location.value.active) {
-    setTimeout(async () => {
-      await open()
-    }, 100)
+    if (!isReady.value) {
+      await new Promise<void>(resolve => watch(isReady, () => resolve(), { once: true }))
+    }
+    await open()
   }
 })
 


### PR DESCRIPTION
Replace `setTimeout(100)` with an explicit `await` on `isReady` before calling `open()` on mount.

The previous timeout could fire before `draftDocuments.load()` finished, causing `selectByFsPath` to fall back to stale SQLite content — dropping any IndexedDB draft slots the user had saved.