### PR TITLE
fix(app): open file for current host route instead of forcing back to last location

### DIFF
--- a/src/app/src/app.vue
+++ b/src/app/src/app.vue
@@ -56,7 +56,7 @@ async function open() {
   await router.push(`/${location.value.feature}`)
 
   if (preferences.value.syncEditorAndRoute) {
-    const selected = await documentTree.selectByRoute(window.location.pathname)
+    const selected = await documentTree.selectByRoute(host.app.getCurrentRoute())
     if (selected) {
       ui.open()
       return

--- a/src/app/src/app.vue
+++ b/src/app/src/app.vue
@@ -6,7 +6,7 @@ import { useStudioState } from './composables/useStudioState'
 import * as locales from '@nuxt/ui/locale'
 
 const { host, ui, isReady, context, documentTree } = useStudio()
-const { location } = useStudioState()
+const { location, preferences } = useStudioState()
 const router = useRouter()
 
 const uiLocale = computed(() => {
@@ -54,6 +54,15 @@ async function editContentFile(fsPath: string) {
 
 async function open() {
   await router.push(`/${location.value.feature}`)
+
+  if (preferences.value.syncEditorAndRoute) {
+    const selected = await documentTree.selectByRoute(window.location.pathname)
+    if (selected) {
+      ui.open()
+      return
+    }
+  }
+
   await documentTree.selectItemByFsPath(location.value.fsPath)
   ui.open()
 }

--- a/src/app/src/composables/useTree.ts
+++ b/src/app/src/composables/useTree.ts
@@ -66,7 +66,7 @@ export const useTree = (type: StudioFeature, host: StudioHost, draft: ReturnType
     return subTree
   })
 
-  async function select(item: TreeItem) {
+  async function select(item: TreeItem, { navigate = true }: { navigate?: boolean } = {}) {
     currentItem.value = item || rootItem.value
 
     setLocation(type, currentItem.value.fsPath)
@@ -75,7 +75,8 @@ export const useTree = (type: StudioFeature, host: StudioHost, draft: ReturnType
       await draft.selectByFsPath(item.fsPath)
 
       if (
-        !preferences.value.syncEditorAndRoute
+        !navigate
+        || !preferences.value.syncEditorAndRoute
         || type === StudioFeature.Media
         || item.name === '.navigation'
         || !item.routePath
@@ -90,12 +91,14 @@ export const useTree = (type: StudioFeature, host: StudioHost, draft: ReturnType
     }
   }
 
-  async function selectByRoute(route: RouteLocationNormalized) {
-    const item = findItemFromRoute(tree.value, route)
+  async function selectByRoute(route: RouteLocationNormalized | string): Promise<boolean> {
+    const path = typeof route === 'string' ? route : route.path
+    const item = findItemFromRoute(tree.value, { path } as RouteLocationNormalized)
 
-    if (!item || item.fsPath === currentItem.value.fsPath) return
+    if (!item || item.fsPath === currentItem.value.fsPath) return false
 
-    await select(item)
+    await select(item, { navigate: false })
+    return true
   }
 
   async function selectItemByFsPath(fsPath: string) {

--- a/src/app/src/composables/useTree.ts
+++ b/src/app/src/composables/useTree.ts
@@ -91,9 +91,8 @@ export const useTree = (type: StudioFeature, host: StudioHost, draft: ReturnType
     }
   }
 
-  async function selectByRoute(route: RouteLocationNormalized | string): Promise<boolean> {
-    const path = typeof route === 'string' ? route : route.path
-    const item = findItemFromRoute(tree.value, { path } as RouteLocationNormalized)
+  async function selectByRoute(route: RouteLocationNormalized): Promise<boolean> {
+    const item = findItemFromRoute(tree.value, route)
 
     if (!item || item.fsPath === currentItem.value.fsPath) return false
 

--- a/src/app/src/types/index.ts
+++ b/src/app/src/types/index.ts
@@ -110,6 +110,7 @@ export interface StudioHost {
     getManifestId: () => Promise<string>
     requestRerender: () => void
     navigateTo: (path: string) => void
+    getCurrentRoute: () => RouteLocationNormalized
     registerServiceWorker: () => void
     unregisterServiceWorker: () => void
   }

--- a/src/module/src/runtime/host.ts
+++ b/src/module/src/runtime/host.ts
@@ -358,6 +358,7 @@ export function useStudioHost(user: StudioUser, repository: Repository): StudioH
       navigateTo: (path: string) => {
         useRouter().push(path)
       },
+      getCurrentRoute: () => useRouter().currentRoute.value,
       registerServiceWorker: () => {
         if ('serviceWorker' in navigator) {
           navigator.serviceWorker.register(`/sw.js?${serviceWorkerVersion}`)


### PR DESCRIPTION
## Summary

When navigating the host browser to a new page (e.g. `/potato`) while Studio had previously been open on a different page (e.g. `/example`), Studio would force the browser back to `/example` instead of following the user to `/potato`.

## Root cause

`open()` in `app.vue` always restored the last stored file (`location.value.fsPath`) regardless of where the user actually navigated. `select()` then called `host.app.navigateTo(item.routePath)`, pushing the host back to the old URL.

This was a side effect of the restore-last-session logic (`location.value.active === true`), which didn't distinguish between a page refresh (restore is correct) and an intentional navigation (Studio should follow the user).

## Behavior comparison

### Before

https://github.com/user-attachments/assets/09d18fad-6d8d-4676-b3a2-cb8b1026c137

### After

https://github.com/user-attachments/assets/90c89692-2dc6-4c96-bacc-6ca5202e6701

