### PR TITLE
fix(tiptap): compare tiptap componentMeta in normalized form

### DIFF
--- a/src/app/src/components/tiptap/extension/TiptapExtensionSlot.vue
+++ b/src/app/src/components/tiptap/extension/TiptapExtensionSlot.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { nodeViewProps, NodeViewWrapper, NodeViewContent } from '@tiptap/vue-3'
+import { kebabCase } from 'scule'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { useStudio } from '../../../composables/useStudio'
 
@@ -26,7 +27,7 @@ const parent = computed(() => {
   return $pos.parent
 })
 
-const componentMeta = computed(() => host.meta.editor.components.get().find(c => c.name === parent.value?.attrs.tag))
+const componentMeta = computed(() => host.meta.editor.components.get().find(c => kebabCase(c.name) === kebabCase(parent.value?.attrs.tag)))
 const slots = computed(() => componentMeta.value?.meta.slots || [])
 const showSlotSelection = computed(() => slots.value.length > 1)
 const usedSlots = computed(() =>


### PR DESCRIPTION
Named slots inside multi-slot components weren't showing up in the editor at all. No label, no slot boundary — the content just rendered inline as if it were part of the document flow, with no indication that it belonged to a named slot.

The slot tiptap component decides whether to render by looking up the parent component in the component metadata registry. That lookup was doing a straight string comparison, but component names in the registry are stored in PascalCase while the tags in the document are kebab-case. So the lookup always came up empty, the component's slots were never found, and the slot UI was suppressed entirely.

The element card was already doing this lookup with a normalized comparison. The slot view just needed to do the same.