### PR TITLE
fix(auth): treat blank MODERATORS allowlist as unset (#509)

### DIFF
--- a/src/module/src/runtime/server/routes/auth/github.get.ts
+++ b/src/module/src/runtime/server/routes/auth/github.get.ts
@@ -200,7 +200,7 @@ export default eventHandler(async (event: H3Event) => {
     user.email = primaryEmail.email
   }
 
-  const moderators = studioConfig?.auth?.github?.moderators?.split(',') || []
+  const moderators = studioConfig?.auth?.github?.moderators?.split(',').filter(Boolean) || []
   if (moderators.length > 0 && !moderators.includes(String(user.email))) {
     throw createError({
       statusCode: 403,

--- a/src/module/src/runtime/server/routes/auth/gitlab.get.ts
+++ b/src/module/src/runtime/server/routes/auth/gitlab.get.ts
@@ -196,7 +196,7 @@ export default eventHandler(async (event: H3Event) => {
     })
   }
 
-  const moderators = studioConfig?.auth?.gitlab?.moderators?.split(',') || []
+  const moderators = studioConfig?.auth?.gitlab?.moderators?.split(',').filter(Boolean) || []
   if (moderators.length > 0 && !moderators.includes(String(user.email))) {
     throw createError({
       statusCode: 403,

--- a/src/module/src/runtime/server/routes/auth/google.get.ts
+++ b/src/module/src/runtime/server/routes/auth/google.get.ts
@@ -187,7 +187,7 @@ export default eventHandler(async (event: H3Event) => {
     })
   }
 
-  const moderators = studioConfig?.auth?.google?.moderators?.split(',') || []
+  const moderators = studioConfig?.auth?.google?.moderators?.split(',').filter(Boolean) || []
 
   if (!moderators.includes(user.email)) {
     if (import.meta.dev && moderators.length === 0) {


### PR DESCRIPTION
Since #478 moved env reads into the studio-env runtime middleware, each provider's `moderators` defaults to `''` instead of `undefined`. The OAuth handlers parsed it as `''.split(',')` -> `['']` (length 1), so the `moderators.length > 0` guard fired and rejected every user with a 403, even when no allowlist was configured.

Filter out blank entries so an unset/blank allowlist yields `[]`, skipping the check and restoring the pre-1.7.0 behaviour (any OAuth'd user allowed). Applies to GitHub, GitLab, and Google.

Fixes #509