### PR TITLE
feat(git): add pull-request generation from CMS UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ pnpm lint
 ### 🔮 Future
 
 - [ ] Advanced conflict resolution
-- [ ] Pull request generation (from a branch to the main one)
+- [x] Pull request generation (from a branch to the main one)
 - [x] AI-powered content suggestions
 - [ ] Media optimization
 

--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -233,6 +233,7 @@ export default defineNuxtConfig({
       branch: 'staging',
       pullRequest: {
         base: 'main',
+        name: 'Content updates from Studio',
       },
     },
   },
@@ -241,13 +242,15 @@ export default defineNuxtConfig({
 
 - `branch` — where Studio commits content changes (typically your staging or preview branch).
 - `pullRequest.base` — the target branch for the review request (typically `main` or production).
+- `pullRequest.name` — optional title for the review request. When omitted, Studio uses the commit message.
 
 When `pullRequest.base` is omitted, Studio keeps the default direct-commit behavior.
 
-You can override the base branch at runtime:
+You can override these options at runtime:
 
 ```bash [.env]
 NUXT_PUBLIC_STUDIO_REPOSITORY_PULL_REQUEST_BASE=main
+NUXT_PUBLIC_STUDIO_REPOSITORY_PULL_REQUEST_NAME="Content updates from Studio"
 ```
 
 ### Internationalization

--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -219,6 +219,37 @@ export default defineNuxtConfig({
 })
 ```
 
+#### Pull request target branch
+
+When Studio commits to a staging branch, you can automatically open a pull request (GitHub) or merge request (GitLab) into your production branch after each publish.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  studio: {
+    repository: {
+      provider: 'github',
+      owner: 'your-username',
+      repo: 'your-repo',
+      branch: 'staging',
+      pullRequest: {
+        base: 'main',
+      },
+    },
+  },
+})
+```
+
+- `branch` — where Studio commits content changes (typically your staging or preview branch).
+- `pullRequest.base` — the target branch for the review request (typically `main` or production).
+
+When `pullRequest.base` is omitted, Studio keeps the default direct-commit behavior.
+
+You can override the base branch at runtime:
+
+```bash [.env]
+NUXT_PUBLIC_STUDIO_REPOSITORY_PULL_REQUEST_BASE=main
+```
+
 ### Internationalization
 
 Nuxt Studio includes built-in internationalization support with the following languages available:

--- a/docs/content/3.git-providers.md
+++ b/docs/content/3.git-providers.md
@@ -210,5 +210,9 @@ Navigate to `https://staging.yourdomain.com/_studio` to edit content. All commit
 
 ### Merging to Production
 
-Once you're satisfied with changes on your staging branch, create a pull request from your staging branch to your main branch to deploy to production.
+Once you're satisfied with changes on your staging branch, merge them into production.
+
+If `repository.pullRequest.base` is configured, Studio automatically creates or reuses an open pull request (GitHub) or merge request (GitLab) from your staging branch to the base branch after each publish. The success screen links directly to the review request.
+
+Otherwise, create a pull request from your staging branch to your main branch manually to deploy to production.
 ::

--- a/docs/content/9.advanced.md
+++ b/docs/content/9.advanced.md
@@ -118,6 +118,10 @@ Studio gathers all draft items that contain changes.
 
 Using your Git provider's API, Studio creates a new commit with all updated files.
 
+#### Review Request (optional)
+
+When `repository.pullRequest.base` is configured, Studio also creates or reuses an open pull request (GitHub) or merge request (GitLab) from the configured branch into the base branch.
+
 #### Deployment Trigger
 
 Your CI/CD platform detects the commit and automatically rebuilds and redeploys your website.

--- a/src/app/src/components/header/HeaderReview.vue
+++ b/src/app/src/components/header/HeaderReview.vue
@@ -74,10 +74,26 @@ async function publishChanges() {
   isPublishing.value = true
   try {
     const changeCount = context.draftCount.value
-    await context.branchActionHandler[StudioBranchActionId.PublishBranch]({ commitMessage: state.commitMessage })
+    const publishResult = await context.branchActionHandler[StudioBranchActionId.PublishBranch]({ commitMessage: state.commitMessage })
 
     state.commitMessage = ''
-    await router.push({ path: '/success', query: { changeCount: changeCount.toString() } })
+    await router.push({
+      path: '/success',
+      query: {
+        changeCount: changeCount.toString(),
+        commitUrl: publishResult.commit.url,
+        ...(publishResult.reviewRequest
+          ? {
+              reviewRequestUrl: publishResult.reviewRequest.url,
+              reviewRequestKind: publishResult.reviewRequest.kind,
+              reviewRequestState: publishResult.reviewRequest.state,
+            }
+          : {}),
+        ...(publishResult.reviewRequestError
+          ? { reviewRequestError: publishResult.reviewRequestError }
+          : {}),
+      },
+    })
   }
   catch (error) {
     const err = error as Error

--- a/src/app/src/composables/useContext.ts
+++ b/src/app/src/composables/useContext.ts
@@ -244,6 +244,7 @@ export const useContext = createSharedComposable((
       }
 
       const pullRequestBase = host.repository.pullRequest?.base
+      const pullRequestName = host.repository.pullRequest?.name?.trim()
       const sourceBranch = host.repository.branch
       let reviewRequest = null
       let reviewRequestError: string | undefined
@@ -251,7 +252,7 @@ export const useContext = createSharedComposable((
       if (pullRequestBase && pullRequestBase !== sourceBranch) {
         try {
           reviewRequest = await gitProvider.api.ensureReviewRequest({
-            title: finalMessage,
+            title: pullRequestName || finalMessage,
             head: sourceBranch,
             base: pullRequestBase,
             commitUrl: commitResult.url,

--- a/src/app/src/composables/useContext.ts
+++ b/src/app/src/composables/useContext.ts
@@ -5,6 +5,7 @@ import {
 } from '../types'
 import type {
   PublishBranchParams,
+  PublishBranchResult,
   RenameFileParams,
   TreeItem,
   UploadMediaParams,
@@ -227,19 +228,56 @@ export const useContext = createSharedComposable((
     }))
   })
 
-  const branchActionHandler: { [K in StudioBranchActionId]: (args: ActionHandlerParams[K]) => Promise<void> } = {
-    [StudioBranchActionId.PublishBranch]: async (params: PublishBranchParams) => {
+  const branchActionHandler: {
+    [StudioBranchActionId.PublishBranch]: (params: PublishBranchParams) => Promise<PublishBranchResult>
+  } = {
+    [StudioBranchActionId.PublishBranch]: async (params: PublishBranchParams): Promise<PublishBranchResult> => {
       const { commitMessage } = params
       const prefix = host.meta.git?.commit?.messagePrefix
       const finalMessage = prefix ? `${prefix} ${commitMessage.trim()}`.trim() : commitMessage.trim()
       const documentFiles = await documentTree.draft.listAsRawFiles()
       const mediaFiles = await mediaTree.draft.listAsRawFiles()
-      await gitProvider.api.commitFiles([...documentFiles, ...mediaFiles], finalMessage)
+      const commitResult = await gitProvider.api.commitFiles([...documentFiles, ...mediaFiles], finalMessage)
+
+      if (!commitResult?.success) {
+        throw new Error('Failed to publish changes')
+      }
+
+      const pullRequestBase = host.repository.pullRequest?.base
+      const sourceBranch = host.repository.branch
+      let reviewRequest = null
+      let reviewRequestError: string | undefined
+
+      if (pullRequestBase && pullRequestBase !== sourceBranch) {
+        try {
+          reviewRequest = await gitProvider.api.ensureReviewRequest({
+            title: finalMessage,
+            head: sourceBranch,
+            base: pullRequestBase,
+            commitUrl: commitResult.url,
+          })
+
+          if (!reviewRequest) {
+            reviewRequestError = 'Failed to create review request'
+          }
+        }
+        catch (error) {
+          reviewRequestError = error instanceof Error ? error.message : 'Failed to create review request'
+          logger.warn('Review request creation failed after successful commit', error)
+        }
+      }
+      else if (pullRequestBase && pullRequestBase === sourceBranch) {
+        logger.warn('repository.pullRequest.base matches repository.branch; skipping review request creation')
+      }
 
       // @ts-expect-error params is null
       await itemActionHandler[StudioItemActionId.RevertAllItems]()
 
-      await router.push('/content')
+      return {
+        commit: commitResult,
+        reviewRequest,
+        reviewRequestError,
+      }
     },
   }
 

--- a/src/app/src/composables/useStudio.ts
+++ b/src/app/src/composables/useStudio.ts
@@ -33,6 +33,7 @@ export const useStudio = createSharedComposable(() => {
     authorName: host.user.get().name,
     authorEmail: host.user.get().email,
     instanceUrl: host.repository.instanceUrl,
+    pullRequest: host.repository.pullRequest,
   }
 
   const gitProvider = useGitProvider(gitOptions, devMode.value)

--- a/src/app/src/locales/en.json
+++ b/src/app/src/locales/en.json
@@ -58,7 +58,21 @@
       "alertTitleWaiting": "Waiting for deployment...",
       "alertTitleComplete": "Deployment complete",
       "alertDescWaiting": "The website needs to be deployed for changes to be visible in Studio.",
-      "alertDescComplete": "A new version of your website has been deployed. Please refresh your app to see changes in Studio."
+      "alertDescComplete": "A new version of your website has been deployed. Please refresh your app to see changes in Studio.",
+      "reviewRequest": {
+        "openPullRequest": "Open pull request",
+        "openMergeRequest": "Open merge request",
+        "openCommit": "View published commit",
+        "failedTitle": "Review request could not be created",
+        "pullRequest": {
+          "created": "Pull request created",
+          "existing": "Existing pull request updated"
+        },
+        "mergeRequest": {
+          "created": "Merge request created",
+          "existing": "Existing merge request updated"
+        }
+      }
     },
     "newVersionBanner": {
       "title": "New website version detected",

--- a/src/app/src/locales/fr.json
+++ b/src/app/src/locales/fr.json
@@ -57,7 +57,21 @@
       "alertTitleWaiting": "En attente de déploiement...",
       "alertTitleComplete": "Déploiement terminé",
       "alertDescWaiting": "Le site web doit être déployé pour que les changements soient visibles dans le Studio.",
-      "alertDescComplete": "Une nouvelle version de votre site a été déployée. Veuillez rafraîchir l'application pour voir les changements dans le Studio."
+      "alertDescComplete": "Une nouvelle version de votre site a été déployée. Veuillez rafraîchir l'application pour voir les changements dans le Studio.",
+      "reviewRequest": {
+        "openPullRequest": "Ouvrir la pull request",
+        "openMergeRequest": "Ouvrir la merge request",
+        "openCommit": "Voir le commit publié",
+        "failedTitle": "Impossible de créer la demande de revue",
+        "pullRequest": {
+          "created": "Pull request créée",
+          "existing": "Pull request existante mise à jour"
+        },
+        "mergeRequest": {
+          "created": "Merge request créée",
+          "existing": "Merge request existante mise à jour"
+        }
+      }
     },
     "newVersionBanner": {
       "title": "Nouvelle version du site détectée",

--- a/src/app/src/pages/success.vue
+++ b/src/app/src/pages/success.vue
@@ -20,6 +20,52 @@ const changeCount = computed(() => {
 })
 const repositoryInfo = computed(() => gitProvider.api.getRepositoryInfo())
 
+const reviewRequestUrl = computed(() => {
+  const url = route.query.reviewRequestUrl
+  return typeof url === 'string' ? url : undefined
+})
+
+const reviewRequestKind = computed(() => {
+  const kind = route.query.reviewRequestKind
+  return kind === 'pull-request' || kind === 'merge-request' ? kind : undefined
+})
+
+const reviewRequestState = computed(() => {
+  const state = route.query.reviewRequestState
+  return state === 'created' || state === 'existing' ? state : undefined
+})
+
+const reviewRequestError = computed(() => {
+  const error = route.query.reviewRequestError
+  return typeof error === 'string' ? error : undefined
+})
+
+const commitUrl = computed(() => {
+  const url = route.query.commitUrl
+  return typeof url === 'string' ? url : undefined
+})
+
+const reviewRequestTitle = computed(() => {
+  if (!reviewRequestKind.value || !reviewRequestState.value) {
+    return ''
+  }
+
+  const kindKey = reviewRequestKind.value === 'pull-request' ? 'pullRequest' : 'mergeRequest'
+  const stateKey = reviewRequestState.value === 'created' ? 'created' : 'existing'
+
+  return t(`studio.publishSuccess.reviewRequest.${kindKey}.${stateKey}`)
+})
+
+const reviewRequestButtonLabel = computed(() => {
+  if (!reviewRequestKind.value) {
+    return ''
+  }
+
+  return reviewRequestKind.value === 'pull-request'
+    ? t('studio.publishSuccess.reviewRequest.openPullRequest')
+    : t('studio.publishSuccess.reviewRequest.openMergeRequest')
+})
+
 const alertDescription = computed(() => {
   if (isWaitingForDeployment.value) {
     return t('studio.publishSuccess.alertDescWaiting')
@@ -97,6 +143,48 @@ onMounted(() => {
           </template>
         </i18n-t>
       </div>
+
+      <UAlert
+        v-if="reviewRequestUrl"
+        icon="i-lucide-git-pull-request"
+        :title="reviewRequestTitle"
+        color="primary"
+        variant="soft"
+      >
+        <template #description>
+          <UButton
+            :label="reviewRequestButtonLabel"
+            icon="i-lucide-external-link"
+            :to="reviewRequestUrl"
+            variant="link"
+            target="_blank"
+            :padded="false"
+          />
+        </template>
+      </UAlert>
+
+      <UAlert
+        v-if="reviewRequestError"
+        icon="i-lucide-alert-triangle"
+        :title="$t('studio.publishSuccess.reviewRequest.failedTitle')"
+        color="warning"
+        variant="soft"
+      >
+        <template #description>
+          <div class="flex flex-col gap-2 items-start">
+            <p>{{ reviewRequestError }}</p>
+            <UButton
+              v-if="commitUrl"
+              :label="$t('studio.publishSuccess.reviewRequest.openCommit')"
+              icon="i-lucide-git-commit-horizontal"
+              :to="commitUrl"
+              variant="link"
+              target="_blank"
+              :padded="false"
+            />
+          </div>
+        </template>
+      </UAlert>
 
       <UAlert
         :icon="isWaitingForDeployment ? 'i-lucide-loader' : 'i-lucide-check'"

--- a/src/app/src/types/context.ts
+++ b/src/app/src/types/context.ts
@@ -1,3 +1,4 @@
+import type { CommitResult, ReviewRequestResult } from './git'
 import type { TreeItem } from './tree'
 
 export enum StudioFeature {
@@ -56,6 +57,12 @@ export interface UploadMediaParams {
 
 export interface PublishBranchParams {
   commitMessage: string
+}
+
+export interface PublishBranchResult {
+  commit: CommitResult
+  reviewRequest: ReviewRequestResult | null
+  reviewRequestError?: string
 }
 
 export type ActionHandlerParams = {

--- a/src/app/src/types/git.ts
+++ b/src/app/src/types/git.ts
@@ -9,6 +9,11 @@ export interface RepositoryPullRequestOptions {
    * When set, Studio commits to `branch` then opens or reuses a review request into this base branch.
    */
   base?: string
+  /**
+   * Title for pull/merge requests created after publishing.
+   * When omitted, the commit message is used.
+   */
+  name?: string
 }
 
 export interface Repository {

--- a/src/app/src/types/git.ts
+++ b/src/app/src/types/git.ts
@@ -3,12 +3,21 @@ import type { StudioFeature } from '../types'
 
 export type GitProviderType = 'github' | 'gitlab'
 
+export interface RepositoryPullRequestOptions {
+  /**
+   * Target branch for pull/merge requests created after publishing.
+   * When set, Studio commits to `branch` then opens or reuses a review request into this base branch.
+   */
+  base?: string
+}
+
 export interface Repository {
   provider: GitProviderType | null
   owner: string
   repo: string
   branch: string
   rootDir: string
+  pullRequest?: RepositoryPullRequestOptions
   /**
    * Can be used to specify the instance URL for self-hosted GitLab instances.
    * @default 'https://gitlab.com'
@@ -29,6 +38,7 @@ export interface GitOptions extends GitBaseOptions {
   rootDir: string
   token: string
   instanceUrl?: string
+  pullRequest?: RepositoryPullRequestOptions
 }
 
 export interface CommitFilesOptions extends GitBaseOptions {
@@ -43,9 +53,32 @@ export interface RawFile {
   encoding?: 'utf-8' | 'base64'
 }
 
+export type ReviewRequestKind = 'pull-request' | 'merge-request'
+
+export type ReviewRequestState = 'created' | 'existing'
+
+export interface EnsureReviewRequestOptions {
+  title: string
+  head: string
+  base: string
+  body?: string
+  commitUrl?: string
+}
+
+export interface ReviewRequestResult {
+  kind: ReviewRequestKind
+  state: ReviewRequestState
+  url: string
+  head: string
+  base: string
+  number?: number
+  iid?: number
+}
+
 export interface GitProviderAPI {
   fetchFile(path: string, options?: { cached?: boolean }): Promise<GitFile | null>
   commitFiles(files: RawFile[], message: string): Promise<CommitResult | null>
+  ensureReviewRequest(options: EnsureReviewRequestOptions): Promise<ReviewRequestResult | null>
   getRepositoryUrl(): string
   getBranchUrl(): string
   getCommitUrl(sha: string): string

--- a/src/app/src/utils/providers/github.ts
+++ b/src/app/src/utils/providers/github.ts
@@ -1,7 +1,7 @@
 import { ofetch } from 'ofetch'
 import { joinURL, withoutTrailingSlash } from 'ufo'
 import { consola } from 'consola'
-import type { GitOptions, GitProviderAPI, GitFile, RawFile, CommitResult, CommitFilesOptions } from '../../types'
+import type { GitOptions, GitProviderAPI, GitFile, RawFile, CommitResult, CommitFilesOptions, EnsureReviewRequestOptions, ReviewRequestResult } from '../../types'
 import { StudioFeature } from '../../types'
 import { DraftStatus } from '../../types/draft'
 
@@ -244,6 +244,93 @@ export function createGitHubProvider(options: GitOptions): GitProviderAPI {
     }
   }
 
+  async function findOpenPullRequest(headRef: string, base: string) {
+    const existingPulls = await $repositoryApi<Array<{
+      number: number
+      html_url: string
+      head: { ref: string }
+      base: { ref: string }
+    }>>('/pulls', {
+      query: {
+        state: 'open',
+        head: headRef,
+        base,
+      },
+    })
+
+    return existingPulls[0] ?? null
+  }
+
+  async function ensureReviewRequest({ title, head, base, body, commitUrl }: EnsureReviewRequestOptions): Promise<ReviewRequestResult | null> {
+    if (!token) {
+      return null
+    }
+
+    const headRef = `${owner}:${head}`
+    const existingPull = await findOpenPullRequest(headRef, base)
+
+    if (existingPull) {
+      return {
+        kind: 'pull-request',
+        state: 'existing',
+        url: existingPull.html_url,
+        head: existingPull.head.ref,
+        base: existingPull.base.ref,
+        number: existingPull.number,
+      }
+    }
+
+    const description = [
+      body,
+      commitUrl ? `Commit: ${commitUrl}` : undefined,
+      'Published via [Nuxt Studio](https://nuxt.studio/)',
+    ].filter(Boolean).join('\n\n')
+
+    try {
+      const createdPull = await $repositoryApi<{
+        number: number
+        html_url: string
+        head: { ref: string }
+        base: { ref: string }
+      }>('/pulls', {
+        method: 'POST',
+        body: JSON.stringify({
+          title,
+          head,
+          base,
+          body: description,
+        }),
+      })
+
+      return {
+        kind: 'pull-request',
+        state: 'created',
+        url: createdPull.html_url,
+        head: createdPull.head.ref,
+        base: createdPull.base.ref,
+        number: createdPull.number,
+      }
+    }
+    catch (error) {
+      if ((error as { status?: number }).status === 422) {
+        const racedPull = await findOpenPullRequest(headRef, base)
+
+        if (racedPull) {
+          return {
+            kind: 'pull-request',
+            state: 'existing',
+            url: racedPull.html_url,
+            head: racedPull.head.ref,
+            base: racedPull.base.ref,
+            number: racedPull.number,
+          }
+        }
+      }
+
+      throw error
+    }
+  }
+
   function getRepositoryUrl() {
     return `${instanceUrl}/${owner}/${repo}`
   }
@@ -274,6 +361,7 @@ export function createGitHubProvider(options: GitOptions): GitProviderAPI {
   return {
     fetchFile,
     commitFiles,
+    ensureReviewRequest,
     getRepositoryUrl,
     getBranchUrl,
     getCommitUrl,

--- a/src/app/src/utils/providers/gitlab.ts
+++ b/src/app/src/utils/providers/gitlab.ts
@@ -1,7 +1,7 @@
 import { ofetch } from 'ofetch'
 import { joinURL, withoutTrailingSlash } from 'ufo'
 import { consola } from 'consola'
-import type { GitOptions, GitProviderAPI, GitFile, RawFile, CommitResult, CommitFilesOptions } from '../../types'
+import type { GitOptions, GitProviderAPI, GitFile, RawFile, CommitResult, CommitFilesOptions, EnsureReviewRequestOptions, ReviewRequestResult } from '../../types'
 import { DraftStatus } from '../../types/draft'
 import { StudioFeature } from '../../types'
 
@@ -171,6 +171,67 @@ export function createGitLabProvider(options: GitOptions): GitProviderAPI {
     }
   }
 
+  async function ensureReviewRequest({ title, head, base, body, commitUrl }: EnsureReviewRequestOptions): Promise<ReviewRequestResult | null> {
+    if (!token) {
+      return null
+    }
+
+    const existingMergeRequests = await $api<Array<{
+      iid: number
+      web_url: string
+      source_branch: string
+      target_branch: string
+    }>>('/merge_requests', {
+      query: {
+        state: 'opened',
+        source_branch: head,
+        target_branch: base,
+      },
+    })
+
+    const existingMergeRequest = existingMergeRequests[0]
+    if (existingMergeRequest) {
+      return {
+        kind: 'merge-request',
+        state: 'existing',
+        url: existingMergeRequest.web_url,
+        head: existingMergeRequest.source_branch,
+        base: existingMergeRequest.target_branch,
+        iid: existingMergeRequest.iid,
+      }
+    }
+
+    const description = [
+      body,
+      commitUrl ? `Commit: ${commitUrl}` : undefined,
+      'Published via [Nuxt Studio](https://nuxt.studio/)',
+    ].filter(Boolean).join('\n\n')
+
+    const createdMergeRequest = await $api<{
+      iid: number
+      web_url: string
+      source_branch: string
+      target_branch: string
+    }>('/merge_requests', {
+      method: 'POST',
+      body: {
+        title,
+        source_branch: head,
+        target_branch: base,
+        description,
+      },
+    })
+
+    return {
+      kind: 'merge-request',
+      state: 'created',
+      url: createdMergeRequest.web_url,
+      head: createdMergeRequest.source_branch,
+      base: createdMergeRequest.target_branch,
+      iid: createdMergeRequest.iid,
+    }
+  }
+
   function getRepositoryUrl() {
     return `${normalizedInstanceUrl}/${owner}/${repo}`
   }
@@ -201,6 +262,7 @@ export function createGitLabProvider(options: GitOptions): GitProviderAPI {
   return {
     fetchFile,
     commitFiles,
+    ensureReviewRequest,
     getRepositoryUrl,
     getBranchUrl,
     getCommitUrl,

--- a/src/app/src/utils/providers/null.ts
+++ b/src/app/src/utils/providers/null.ts
@@ -1,4 +1,4 @@
-import type { GitOptions, GitProviderAPI, GitFile, RawFile, CommitResult } from '../../types'
+import type { GitOptions, GitProviderAPI, GitFile, RawFile, CommitResult, EnsureReviewRequestOptions, ReviewRequestResult } from '../../types'
 
 /**
  * Null provider for development/local usage
@@ -8,6 +8,7 @@ export function createNullProvider(_options: GitOptions): GitProviderAPI {
   return {
     fetchFile: (_path: string, _options: { cached?: boolean } = {}): Promise<GitFile | null> => Promise.resolve(null),
     commitFiles: (_files: RawFile[], _message: string): Promise<CommitResult | null> => Promise.resolve(null),
+    ensureReviewRequest: (_options: EnsureReviewRequestOptions): Promise<ReviewRequestResult | null> => Promise.resolve(null),
     getRepositoryUrl: () => '',
     getBranchUrl: () => '',
     getCommitUrl: () => '',

--- a/src/app/test/integration/publish.test.ts
+++ b/src/app/test/integration/publish.test.ts
@@ -205,6 +205,40 @@ describe('PublishBranch - Review requests', () => {
     expect(result.reviewRequestError).toBeUndefined()
   })
 
+  it('uses a custom review request title when pullRequest.name is configured', async () => {
+    const hostWithPullRequest: StudioHost = {
+      ...mockHost,
+      repository: {
+        ...mockHost.repository,
+        branch: 'staging',
+        pullRequest: { base: 'main', name: 'Content updates from Studio' },
+      },
+    }
+    const git = createMockGit()
+    ;(git.api.ensureReviewRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      kind: 'pull-request',
+      state: 'created',
+      url: 'https://github.com/owner/repo/pull/1',
+      head: 'staging',
+      base: 'main',
+      number: 1,
+    })
+    context = await cleanAndSetupContext(hostWithPullRequest, git)
+
+    await mockHost.document.db.create(documentFsPath, 'Test content')
+    await context.activeTree.value.draft.load()
+    await context.activeTree.value.selectItemByFsPath(documentFsPath)
+
+    await context.branchActionHandler[StudioBranchActionId.PublishBranch]({ commitMessage: 'Update content' })
+
+    expect(git.api.ensureReviewRequest).toHaveBeenCalledWith({
+      title: 'Content updates from Studio',
+      head: 'staging',
+      base: 'main',
+      commitUrl: 'https://example.com/commit/abc123',
+    })
+  })
+
   it('reuses an existing review request when the provider returns one', async () => {
     const hostWithPullRequest: StudioHost = {
       ...mockHost,

--- a/src/app/test/integration/publish.test.ts
+++ b/src/app/test/integration/publish.test.ts
@@ -2,6 +2,7 @@ import { type vi, describe, it, expect, beforeEach } from 'vitest'
 import { StudioBranchActionId, type StudioHost } from '../../src/types'
 import { generateUniqueDocumentFsPath } from '../utils'
 import { mockHost, mockGit, routeState, cleanAndSetupContext } from '../utils/context'
+import { createMockGit } from '../mocks/git'
 
 describe('PublishBranch - Commit Message Prefix', () => {
   let context: Awaited<ReturnType<typeof cleanAndSetupContext>>
@@ -67,5 +68,174 @@ describe('PublishBranch - Commit Message Prefix', () => {
     expect(mockGit.api.commitFiles).toHaveBeenCalledTimes(1)
     const [, commitMessage] = (mockGit.api.commitFiles as ReturnType<typeof vi.fn>).mock.calls[0]
     expect(commitMessage).toBe('docs: Update readme')
+  })
+})
+
+describe('PublishBranch - Review requests', () => {
+  let context: Awaited<ReturnType<typeof cleanAndSetupContext>>
+  let documentFsPath: string
+
+  beforeEach(async () => {
+    routeState.name = 'content'
+    documentFsPath = generateUniqueDocumentFsPath('document')
+    context = await cleanAndSetupContext(mockHost, mockGit)
+  })
+
+  it('does not create a review request when pullRequest.base is not configured', async () => {
+    await mockHost.document.db.create(documentFsPath, 'Test content')
+    await context.activeTree.value.draft.load()
+    await context.activeTree.value.selectItemByFsPath(documentFsPath)
+
+    const result = await context.branchActionHandler[StudioBranchActionId.PublishBranch]({ commitMessage: 'Update content' })
+
+    expect(mockGit.api.ensureReviewRequest).not.toHaveBeenCalled()
+    expect(result.reviewRequest).toBeNull()
+    expect(result.reviewRequestError).toBeUndefined()
+  })
+
+  it('creates a review request after a successful commit when pullRequest.base is configured', async () => {
+    const hostWithPullRequest: StudioHost = {
+      ...mockHost,
+      repository: {
+        ...mockHost.repository,
+        branch: 'staging',
+        pullRequest: { base: 'main' },
+      },
+    }
+    const git = createMockGit()
+    ;(git.api.ensureReviewRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      kind: 'pull-request',
+      state: 'created',
+      url: 'https://github.com/owner/repo/pull/1',
+      head: 'staging',
+      base: 'main',
+      number: 1,
+    })
+    context = await cleanAndSetupContext(hostWithPullRequest, git)
+
+    await mockHost.document.db.create(documentFsPath, 'Test content')
+    await context.activeTree.value.draft.load()
+    await context.activeTree.value.selectItemByFsPath(documentFsPath)
+
+    const result = await context.branchActionHandler[StudioBranchActionId.PublishBranch]({ commitMessage: 'Update content' })
+
+    expect(git.api.ensureReviewRequest).toHaveBeenCalledWith({
+      title: 'Update content',
+      head: 'staging',
+      base: 'main',
+      commitUrl: 'https://example.com/commit/abc123',
+    })
+    expect(result.reviewRequest).toMatchObject({
+      kind: 'pull-request',
+      state: 'created',
+      url: 'https://github.com/owner/repo/pull/1',
+    })
+  })
+
+  it('returns a partial success when review request creation fails after commit', async () => {
+    const hostWithPullRequest: StudioHost = {
+      ...mockHost,
+      repository: {
+        ...mockHost.repository,
+        branch: 'staging',
+        pullRequest: { base: 'main' },
+      },
+    }
+    const git = createMockGit()
+    ;(git.api.ensureReviewRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('API rate limit exceeded'))
+    context = await cleanAndSetupContext(hostWithPullRequest, git)
+
+    await mockHost.document.db.create(documentFsPath, 'Test content')
+    await context.activeTree.value.draft.load()
+    await context.activeTree.value.selectItemByFsPath(documentFsPath)
+
+    const result = await context.branchActionHandler[StudioBranchActionId.PublishBranch]({ commitMessage: 'Update content' })
+
+    expect(git.api.commitFiles).toHaveBeenCalledTimes(1)
+    expect(result.commit.success).toBe(true)
+    expect(result.reviewRequest).toBeNull()
+    expect(result.reviewRequestError).toBe('API rate limit exceeded')
+    expect(context.draftCount.value).toBe(0)
+  })
+
+  it('returns a partial success when ensureReviewRequest resolves null', async () => {
+    const hostWithPullRequest: StudioHost = {
+      ...mockHost,
+      repository: {
+        ...mockHost.repository,
+        branch: 'staging',
+        pullRequest: { base: 'main' },
+      },
+    }
+    const git = createMockGit()
+    ;(git.api.ensureReviewRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null)
+    context = await cleanAndSetupContext(hostWithPullRequest, git)
+
+    await mockHost.document.db.create(documentFsPath, 'Test content')
+    await context.activeTree.value.draft.load()
+    await context.activeTree.value.selectItemByFsPath(documentFsPath)
+
+    const result = await context.branchActionHandler[StudioBranchActionId.PublishBranch]({ commitMessage: 'Update content' })
+
+    expect(result.commit.success).toBe(true)
+    expect(result.reviewRequest).toBeNull()
+    expect(result.reviewRequestError).toBe('Failed to create review request')
+  })
+
+  it('skips review request creation when pullRequest.base matches repository.branch', async () => {
+    const hostWithSameBranch: StudioHost = {
+      ...mockHost,
+      repository: {
+        ...mockHost.repository,
+        branch: 'main',
+        pullRequest: { base: 'main' },
+      },
+    }
+    const git = createMockGit()
+    context = await cleanAndSetupContext(hostWithSameBranch, git)
+
+    await mockHost.document.db.create(documentFsPath, 'Test content')
+    await context.activeTree.value.draft.load()
+    await context.activeTree.value.selectItemByFsPath(documentFsPath)
+
+    const result = await context.branchActionHandler[StudioBranchActionId.PublishBranch]({ commitMessage: 'Update content' })
+
+    expect(git.api.ensureReviewRequest).not.toHaveBeenCalled()
+    expect(result.reviewRequest).toBeNull()
+    expect(result.reviewRequestError).toBeUndefined()
+  })
+
+  it('reuses an existing review request when the provider returns one', async () => {
+    const hostWithPullRequest: StudioHost = {
+      ...mockHost,
+      repository: {
+        ...mockHost.repository,
+        branch: 'staging',
+        pullRequest: { base: 'main' },
+      },
+    }
+    const git = createMockGit()
+    ;(git.api.ensureReviewRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      kind: 'pull-request',
+      state: 'existing',
+      url: 'https://github.com/owner/repo/pull/42',
+      head: 'staging',
+      base: 'main',
+      number: 42,
+    })
+    context = await cleanAndSetupContext(hostWithPullRequest, git)
+
+    await mockHost.document.db.create(documentFsPath, 'Test content')
+    await context.activeTree.value.draft.load()
+    await context.activeTree.value.selectItemByFsPath(documentFsPath)
+
+    const result = await context.branchActionHandler[StudioBranchActionId.PublishBranch]({ commitMessage: 'Update content' })
+
+    expect(result.reviewRequest).toMatchObject({
+      kind: 'pull-request',
+      state: 'existing',
+      url: 'https://github.com/owner/repo/pull/42',
+    })
+    expect(result.reviewRequestError).toBeUndefined()
   })
 })

--- a/src/app/test/mocks/git.ts
+++ b/src/app/test/mocks/git.ts
@@ -8,6 +8,7 @@ export const createMockGit = (remoteFile?: GithubFile): ReturnType<typeof useGit
   api: {
     fetchFile: vi.fn().mockResolvedValue(remoteFile || createMockGithubFile()),
     commitFiles: vi.fn().mockResolvedValue({ success: true, commitSha: 'abc123', url: 'https://example.com/commit/abc123' }),
+    ensureReviewRequest: vi.fn().mockResolvedValue(null),
     getRepositoryUrl: vi.fn().mockReturnValue('https://github.com/owner/repo'),
     getBranchUrl: vi.fn().mockReturnValue('https://github.com/owner/repo/tree/main'),
     getCommitUrl: vi.fn().mockReturnValue('https://github.com/owner/repo/commit/abc123'),

--- a/src/app/test/unit/utils/providers/github.test.ts
+++ b/src/app/test/unit/utils/providers/github.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DraftStatus } from '../../../../src/types/draft'
+import { createGitHubProvider } from '../../../../src/utils/providers/github'
+
+const existingPull = {
+  number: 42,
+  html_url: 'https://github.com/acme/docs/pull/42',
+  head: { ref: 'staging' },
+  base: { ref: 'main' },
+}
+
+const createdPull = {
+  number: 43,
+  html_url: 'https://github.com/acme/docs/pull/43',
+  head: { ref: 'staging' },
+  base: { ref: 'main' },
+}
+
+function createApiHandler(options?: { existingPull?: typeof existingPull | null }) {
+  return (
+    request: string,
+    requestOptions?: { method?: string, query?: Record<string, string>, body?: string },
+  ) => {
+    if (request === '/pulls' && !requestOptions?.method) {
+      return Promise.resolve(options?.existingPull ? [options.existingPull] : [])
+    }
+
+    if (request === '/pulls' && requestOptions?.method === 'POST') {
+      return Promise.resolve(createdPull)
+    }
+
+    if (request === '/git/refs/heads/dev') {
+      return Promise.resolve({ object: { sha: 'base-sha' } })
+    }
+
+    if (request === '/git/commits/base-sha') {
+      return Promise.resolve({ tree: { sha: 'tree-sha' } })
+    }
+
+    if (request === '/git/blobs' && requestOptions?.method === 'POST') {
+      return Promise.resolve({ sha: 'blob-sha' })
+    }
+
+    if (request === '/git/trees' && requestOptions?.method === 'POST') {
+      return Promise.resolve({ sha: 'new-tree-sha' })
+    }
+
+    if (request === '/git/commits' && requestOptions?.method === 'POST') {
+      return Promise.resolve({ sha: 'commit-sha' })
+    }
+
+    if (request === '/git/refs/heads/dev' && requestOptions?.method === 'PATCH') {
+      return Promise.resolve({})
+    }
+
+    return Promise.reject(new Error(`Unexpected request: ${request} ${requestOptions?.method ?? ''}`))
+  }
+}
+
+const mock$repositoryApi = vi.fn(createApiHandler())
+const mock$userApi = vi.fn(() => Promise.resolve({ login: 'author', email: 'author@example.com', name: 'Author' }))
+
+vi.mock('ofetch', () => ({
+  ofetch: {
+    create: vi.fn((config: { baseURL?: string }) => {
+      if (config.baseURL?.endsWith('/repos/acme/docs')) {
+        return mock$repositoryApi
+      }
+
+      return mock$userApi
+    }),
+  },
+}))
+
+const baseGitOptions = {
+  provider: 'github' as const,
+  owner: 'acme',
+  repo: 'docs',
+  branch: 'dev',
+  rootDir: '',
+  authorName: 'Test Author',
+  authorEmail: 'author@example.com',
+  token: 'ghp_test-token',
+  instanceUrl: 'https://github.com',
+} as const
+
+describe('createGitHubProvider / ensureReviewRequest', () => {
+  beforeEach(() => {
+    mock$repositoryApi.mockImplementation(createApiHandler())
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns an existing open pull request when one already exists', async () => {
+    mock$repositoryApi.mockImplementation(createApiHandler({ existingPull }))
+
+    const provider = createGitHubProvider({ ...baseGitOptions })
+    const result = await provider.ensureReviewRequest({
+      title: 'content: update homepage',
+      head: 'staging',
+      base: 'main',
+      commitUrl: 'https://github.com/acme/docs/commit/abc123',
+    })
+
+    expect(result).toEqual({
+      kind: 'pull-request',
+      state: 'existing',
+      url: existingPull.html_url,
+      head: 'staging',
+      base: 'main',
+      number: 42,
+    })
+
+    expect(mock$repositoryApi).toHaveBeenCalledWith('/pulls', {
+      query: {
+        state: 'open',
+        head: 'acme:staging',
+        base: 'main',
+      },
+    })
+  })
+
+  it('creates a pull request when none exists', async () => {
+    const provider = createGitHubProvider({ ...baseGitOptions })
+    const result = await provider.ensureReviewRequest({
+      title: 'content: update homepage',
+      head: 'staging',
+      base: 'main',
+      commitUrl: 'https://github.com/acme/docs/commit/abc123',
+    })
+
+    expect(result).toEqual({
+      kind: 'pull-request',
+      state: 'created',
+      url: createdPull.html_url,
+      head: 'staging',
+      base: 'main',
+      number: 43,
+    })
+
+    const [, requestInit] = mock$repositoryApi.mock.calls.find(
+      ([request, options]) => request === '/pulls' && options?.method === 'POST',
+    ) as [string, { method: string, body: string }]
+
+    expect(JSON.parse(requestInit.body)).toMatchObject({
+      title: 'content: update homepage',
+      head: 'staging',
+      base: 'main',
+    })
+  })
+
+  it('does not call the API when token is missing', async () => {
+    const provider = createGitHubProvider({
+      ...baseGitOptions,
+      token: '',
+    })
+
+    const result = await provider.ensureReviewRequest({
+      title: 'content: update homepage',
+      head: 'staging',
+      base: 'main',
+    })
+
+    expect(result).toBeNull()
+    expect(mock$repositoryApi).not.toHaveBeenCalled()
+  })
+
+  it('returns an existing pull request when creation races with a duplicate 422', async () => {
+    let pullListCalls = 0
+
+    mock$repositoryApi.mockImplementation((
+      request: string,
+      requestOptions?: { method?: string, query?: Record<string, string> },
+    ) => {
+      if (request === '/pulls' && !requestOptions?.method) {
+        pullListCalls += 1
+        return Promise.resolve(pullListCalls === 1 ? [] : [existingPull])
+      }
+
+      if (request === '/pulls' && requestOptions?.method === 'POST') {
+        const error = new Error('Validation Failed') as Error & { status: number }
+        error.status = 422
+        return Promise.reject(error)
+      }
+
+      return Promise.reject(new Error(`Unexpected request: ${request} ${requestOptions?.method ?? ''}`))
+    })
+
+    const provider = createGitHubProvider({ ...baseGitOptions })
+    const result = await provider.ensureReviewRequest({
+      title: 'content: update homepage',
+      head: 'staging',
+      base: 'main',
+    })
+
+    expect(result).toEqual({
+      kind: 'pull-request',
+      state: 'existing',
+      url: existingPull.html_url,
+      head: 'staging',
+      base: 'main',
+      number: 42,
+    })
+
+    expect(pullListCalls).toBe(2)
+  })
+})
+
+describe('createGitHubProvider / commitFiles', () => {
+  beforeEach(() => {
+    mock$repositoryApi.mockImplementation(createApiHandler())
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('commits files to the configured branch', async () => {
+    const provider = createGitHubProvider({ ...baseGitOptions })
+
+    const result = await provider.commitFiles(
+      [{
+        path: 'content/index.md',
+        status: DraftStatus.Created,
+        content: '# Hello',
+        encoding: 'utf-8',
+      }],
+      'docs: welcome',
+    )
+
+    expect(result).toEqual({
+      success: true,
+      commitSha: 'commit-sha',
+      url: 'https://github.com/acme/docs/commit/commit-sha',
+    })
+  })
+})

--- a/src/app/test/unit/utils/providers/gitlab.test.ts
+++ b/src/app/test/unit/utils/providers/gitlab.test.ts
@@ -2,15 +2,36 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DraftStatus } from '../../../../src/types/draft'
 import { createGitLabProvider } from '../../../../src/utils/providers/gitlab'
 
-function createCommitsApiHandler() {
+function createCommitsApiHandler(options?: {
+  existingMergeRequest?: {
+    iid: number
+    web_url: string
+    source_branch: string
+    target_branch: string
+  } | null
+}) {
   return (
     request: string,
-    options?: { method?: string, body?: Record<string, unknown> },
+    requestOptions?: { method?: string, query?: Record<string, string>, body?: Record<string, unknown> },
   ) => {
-    if (request === '/repository/commits' && options?.method === 'POST') {
+    if (request === '/merge_requests' && !requestOptions?.method) {
+      return Promise.resolve(options?.existingMergeRequest ? [options.existingMergeRequest] : [])
+    }
+
+    if (request === '/merge_requests' && requestOptions?.method === 'POST') {
+      return Promise.resolve({
+        iid: 12,
+        web_url: 'https://gitlab.example.com/team-communication/numberly-2026/-/merge_requests/12',
+        source_branch: 'dev',
+        target_branch: 'main',
+      })
+    }
+
+    if (request === '/repository/commits' && requestOptions?.method === 'POST') {
       return Promise.resolve({ id: 'a1b2c3d4e5f6' })
     }
-    return Promise.reject(new Error(`Unexpected request: ${request} ${options?.method ?? ''}`))
+
+    return Promise.reject(new Error(`Unexpected request: ${request} ${requestOptions?.method ?? ''}`))
   }
 }
 
@@ -182,6 +203,97 @@ describe('createGitLabProvider / commitFiles', () => {
       [{ path: 'x.md', status: DraftStatus.Created, content: 'x', encoding: 'utf-8' }],
       'msg',
     )
+
+    expect(result).toBeNull()
+    expect(mock$api).not.toHaveBeenCalled()
+  })
+})
+
+describe('createGitLabProvider / ensureReviewRequest', () => {
+  const existingMergeRequest = {
+    iid: 7,
+    web_url: 'https://gitlab.example.com/team-communication/numberly-2026/-/merge_requests/7',
+    source_branch: 'dev',
+    target_branch: 'main',
+  }
+
+  beforeEach(() => {
+    mock$api.mockImplementation(createCommitsApiHandler())
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns an existing open merge request when one already exists', async () => {
+    mock$api.mockImplementation(createCommitsApiHandler({ existingMergeRequest }))
+
+    const provider = createGitLabProvider({ ...baseGitOptions })
+    const result = await provider.ensureReviewRequest({
+      title: 'content: update homepage',
+      head: 'dev',
+      base: 'main',
+      commitUrl: 'https://gitlab.example.com/team-communication/numberly-2026/-/commit/a1b2c3d4e5f6',
+    })
+
+    expect(result).toEqual({
+      kind: 'merge-request',
+      state: 'existing',
+      url: existingMergeRequest.web_url,
+      head: 'dev',
+      base: 'main',
+      iid: 7,
+    })
+
+    expect(mock$api).toHaveBeenCalledWith('/merge_requests', {
+      query: {
+        state: 'opened',
+        source_branch: 'dev',
+        target_branch: 'main',
+      },
+    })
+  })
+
+  it('creates a merge request when none exists', async () => {
+    const provider = createGitLabProvider({ ...baseGitOptions })
+    const result = await provider.ensureReviewRequest({
+      title: 'content: update homepage',
+      head: 'dev',
+      base: 'main',
+      commitUrl: 'https://gitlab.example.com/team-communication/numberly-2026/-/commit/a1b2c3d4e5f6',
+    })
+
+    expect(result).toEqual({
+      kind: 'merge-request',
+      state: 'created',
+      url: 'https://gitlab.example.com/team-communication/numberly-2026/-/merge_requests/12',
+      head: 'dev',
+      base: 'main',
+      iid: 12,
+    })
+
+    const [, requestInit] = mock$api.mock.calls.find(
+      ([request, options]) => request === '/merge_requests' && options?.method === 'POST',
+    ) as [string, { method: string, body: Record<string, unknown> }]
+
+    expect(requestInit.body).toMatchObject({
+      title: 'content: update homepage',
+      source_branch: 'dev',
+      target_branch: 'main',
+    })
+  })
+
+  it('does not call the API when token is missing', async () => {
+    const provider = createGitLabProvider({
+      ...baseGitOptions,
+      token: '',
+    })
+
+    const result = await provider.ensureReviewRequest({
+      title: 'content: update homepage',
+      head: 'dev',
+      base: 'main',
+    })
 
     expect(result).toBeNull()
     expect(mock$api).not.toHaveBeenCalled()

--- a/src/module/src/module.ts
+++ b/src/module/src/module.ts
@@ -134,6 +134,12 @@ interface RepositoryOptions {
      * @example 'main'
      */
     base?: string
+    /**
+     * Title for the pull request (GitHub) or merge request (GitLab) when one is created.
+     * When omitted, the commit message is used.
+     * @example 'Content updates from Studio'
+     */
+    name?: string
   }
 }
 

--- a/src/module/src/module.ts
+++ b/src/module/src/module.ts
@@ -124,6 +124,17 @@ interface RepositoryOptions {
    * @default true
    */
   private?: boolean
+  /**
+   * Pull/merge request settings for staging-to-production workflows.
+   * When `base` is set, Studio commits to `branch` then creates or reuses a review request into `base`.
+   */
+  pullRequest?: {
+    /**
+     * Target branch for the pull request (GitHub) or merge request (GitLab).
+     * @example 'main'
+     */
+    base?: string
+  }
 }
 
 interface GitHubRepositoryOptions extends RepositoryOptions {


### PR DESCRIPTION
Closes [nuxt-content/nuxt-studio#366](https://github.com/nuxt-content/nuxt-studio/issues/366).

## Problem

Content teams often work on a **staging branch** (preview environment) and promote changes to **production** via a pull request (GitHub) or merge request (GitLab). Before this change, Nuxt Studio could commit to a configured branch but left the PR/MR step entirely manual.

## Solution

Add opt-in `repository.pullRequest` options. When `pullRequest.base` is set:

1. Studio commits drafts to `repository.branch` (unchanged behavior).
2. Studio creates or reuses an open PR/MR from that branch into `pullRequest.base`.
3. The success screen links to the review request, or warns on partial failure with a direct link to the landed commit.

When `pullRequest.base` is omitted, behavior is unchanged: direct commit only.

Optionally, `pullRequest.name` sets a custom title for newly created PR/MR. When omitted, the commit message is used.

## Configuration

```ts
// nuxt.config.ts
export default defineNuxtConfig({
  studio: {
    repository: {
      provider: 'github', // or 'gitlab'
      owner: 'your-org',
      repo: 'your-repo',
      branch: 'staging',   // commit target + deployed preview branch
      pullRequest: {
        base: 'main',      // PR/MR target branch
        name: 'Content updates from Studio', // optional PR/MR title
      },
    },
  },
})
```

Runtime override (Nuxt public runtime config):

```bash
NUXT_PUBLIC_STUDIO_REPOSITORY_PULL_REQUEST_BASE=main
NUXT_PUBLIC_STUDIO_REPOSITORY_PULL_REQUEST_NAME="Content updates from Studio"
```

| Option | Role |
|--------|------|
| `repository.branch` | Where Studio commits and what the deployed site reflects |
| `repository.pullRequest.base` | Target branch for the review request |
| `repository.pullRequest.name` | Optional title for newly created PR/MR (defaults to commit message) |

User-facing docs: [`docs/content/2.setup.md`](../docs/content/2.setup.md), [`docs/content/3.git-providers.md`](../docs/content/3.git-providers.md), [`docs/content/9.advanced.md`](../docs/content/9.advanced.md).

## Publish flow

```mermaid
sequenceDiagram
  participant Review as HeaderReview
  participant Ctx as useContext.PublishBranch
  participant Provider as GitProviderAPI
  participant Remote as GitHub / GitLab API
  participant Success as /success

  Review->>Ctx: commitMessage
  Ctx->>Provider: commitFiles(rawFiles, message)
  Provider->>Remote: commit to repository.branch
  Remote-->>Provider: CommitResult
  alt pullRequest.base set and differs from branch
    Ctx->>Provider: ensureReviewRequest({ head, base, title, commitUrl })
    Provider->>Remote: GET open PR/MR
    alt none exists
      Provider->>Remote: POST PR/MR
    end
    Remote-->>Provider: ReviewRequestResult
  end
  Ctx->>Ctx: clear drafts (always after successful commit)
  Ctx-->>Review: PublishBranchResult
  Review->>Success: query params (changeCount, commitUrl, review request metadata)
```

## Behavior matrix

| Scenario | Commit | Drafts cleared | Review request | UI |
|----------|--------|----------------|----------------|-----|
| No `pullRequest.base` | Yes | Yes | Skipped | Standard success |
| `base` ≠ `branch` | Yes | Yes | Created or reused | Success + PR/MR link |
| Open PR/MR already exists | Yes | Yes | Reused (`state: 'existing'`) | Success + link |
| `base` === `branch` | Yes | Yes | Skipped (config warning in logs) | Standard success |
| Commit fails | No | No | Not attempted | `/error` |
| Commit OK, PR/MR fails | Yes | Yes | Error recorded | Success + warning + **commit link** |
| `ensureReviewRequest` returns `null` | Yes | Yes | Treated as failure | Success + warning + commit link |
| GitHub 422 on create (race) | Yes | Yes | Re-lookup → reuse existing | Success + link |

**Partial failure is intentional:** once content is on the staging branch, drafts are cleared even if PR/MR creation fails. The user can open the commit from the success screen and create the review request manually if needed.

## Architecture notes

- **Client-side providers** — same model as `commitFiles`: `ofetch` from the Studio app using the user's OAuth token or PAT. No new server routes.
- **Orchestration** — `PublishBranch` in `useContext.ts` chains commit → optional review request → draft cleanup.
- **Provider contract** — new `GitProviderAPI.ensureReviewRequest()` with provider-neutral `ReviewRequestResult` (`kind`, `state`, `url`, `head`, `base`).
- **Return type** — `PublishBranchResult` carries `commit`, optional `reviewRequest`, and optional `reviewRequestError` back to the UI.
- **Review request title** — `pullRequest.name` when configured, otherwise the commit message. Only applied when creating a new PR/MR; existing open requests are reused as-is.

### GitHub (`ensureReviewRequest`)

1. `GET /repos/{owner}/{repo}/pulls?state=open&head={owner}:{branch}&base={base}`
2. If found → return `state: 'existing'`
3. Else `POST /pulls` with `pullRequest.name` or commit message as title
4. On **422** (duplicate created concurrently) → re-run step 1 and reuse if found

### GitLab (`ensureReviewRequest`)

1. `GET /projects/{id}/merge_requests?state=opened&source_branch={head}&target_branch={base}`
2. If found → return `state: 'existing'`
3. Else `POST /merge_requests` with `pullRequest.name` or commit message as title

## Key files

| Area | Path |
|------|------|
| Module options | `src/module/src/module.ts` — `repository.pullRequest.base`, `repository.pullRequest.name` |
| Types | `src/app/src/types/git.ts`, `src/app/src/types/context.ts` |
| Publish orchestration | `src/app/src/composables/useContext.ts` |
| GitHub provider | `src/app/src/utils/providers/github.ts` |
| GitLab provider | `src/app/src/utils/providers/gitlab.ts` |
| Null provider (dev) | `src/app/src/utils/providers/null.ts` |
| Review UI | `src/app/src/components/header/HeaderReview.vue` |
| Success UI | `src/app/src/pages/success.vue` |
| i18n | `src/app/src/locales/en.json`, `fr.json` (`studio.publishSuccess.reviewRequest.*`) |

## Tests

| File | Coverage |
|------|----------|
| `src/app/test/integration/publish.test.ts` | Direct mode, PR mode, custom `pullRequest.name`, partial failure (throw), null result, `base === branch` skip, existing request reuse |
| `src/app/test/unit/utils/providers/github.test.ts` | Existing PR lookup, create payload, 422 race recovery, no token |
| `src/app/test/unit/utils/providers/gitlab.test.ts` | Existing MR lookup, create payload, no token |
| `src/app/test/mocks/git.ts` | `ensureReviewRequest` mock |

Run:

```bash
nr test src/app/test/integration/publish.test.ts
nr test src/app/test/unit/utils/providers/github.test.ts
nr test src/app/test/unit/utils/providers/gitlab.test.ts
```

## Manual QA checklist

- [ ] Publish without `pullRequest.base` — no PR/MR step, standard success
- [ ] Publish with `branch: staging`, `pullRequest.base: main` on GitHub — PR link on success
- [ ] Publish with `pullRequest.name` set — newly created PR/MR uses the configured title
- [ ] Publish again while PR is still open — reuses existing PR (no duplicate)
- [ ] Publish with `pullRequest.base` equal to `branch` — commit only, no PR attempt
- [ ] Revoke PR creation permission / use protected base — commit lands, warning + commit link on success
- [ ] Repeat above on GitLab — MR link on success

## Out of scope (by design)

- Per-publish feature branches
- Editor-selectable base branch in the UI
- Auto-merge
- Server-side Git API proxy
- Fork-based `head` refs (same-repo staging → production only)