### PR TITLE
feat(gitlab): handle 401 expired token to display logout/login alert

### DIFF
--- a/src/app/src/components/header/HeaderReview.vue
+++ b/src/app/src/components/header/HeaderReview.vue
@@ -7,6 +7,7 @@ import { StudioBranchActionId } from '../../types'
 import { useStudioState } from '../../composables/useStudioState'
 import { useI18n } from 'vue-i18n'
 import { useAI } from '../../composables/useAI'
+import { GITLAB_TOKEN_EXPIRED_ERROR_CODE, isGitLabTokenExpiredError } from '../../utils/providers/gitlab-errors'
 
 const router = useRouter()
 const { location } = useStudioState()
@@ -80,6 +81,16 @@ async function publishChanges() {
     await router.push({ path: '/success', query: { changeCount: changeCount.toString() } })
   }
   catch (error) {
+    if (isGitLabTokenExpiredError(error)) {
+      await router.push({
+        path: '/error',
+        query: {
+          code: GITLAB_TOKEN_EXPIRED_ERROR_CODE,
+        },
+      })
+      return
+    }
+
     const err = error as Error
     await router.push({
       path: '/error',

--- a/src/app/src/locales/en.json
+++ b/src/app/src/locales/en.json
@@ -43,7 +43,9 @@
       "failedTitle": "Publish Failed",
       "summary": "on {branch} of {repo} repository",
       "errorTitle": "Error during {providerName} publish",
-      "failedGeneric": "Failed to publish changes"
+      "failedGeneric": "Failed to publish changes",
+      "gitlabTokenExpiredTitle": "Your GitLab session has expired",
+      "gitlabTokenExpiredDescription": "You have been logged in for a while and your connection to GitLab is no longer valid. Sign out, then sign in again to publish your changes."
     },
     "review": {
       "title": "Review changes",

--- a/src/app/src/locales/fr.json
+++ b/src/app/src/locales/fr.json
@@ -42,7 +42,9 @@
       "failedTitle": "Échec de la publication",
       "summary": "sur la branche {branch} du dépôt {repo}",
       "errorTitle": "Erreur lors de la publication sur {providerName}",
-      "failedGeneric": "Échec de la publication des changements"
+      "failedGeneric": "Échec de la publication des changements",
+      "gitlabTokenExpiredTitle": "Votre session GitLab a expiré",
+      "gitlabTokenExpiredDescription": "Vous êtes connecté depuis un certain temps et votre connexion à GitLab n'est plus valide. Déconnectez-vous, puis reconnectez-vous pour publier vos changements."
     },
     "review": {
       "title": "Changements à valider",

--- a/src/app/src/pages/error.vue
+++ b/src/app/src/pages/error.vue
@@ -3,20 +3,42 @@ import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useStudio } from '../composables/useStudio'
 import { useI18n } from 'vue-i18n'
+import { GITLAB_TOKEN_EXPIRED_ERROR_CODE } from '../utils/providers/gitlab-errors'
 
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
-const { gitProvider } = useStudio()
+const { gitProvider, host } = useStudio()
+
+const isGitLabTokenExpired = computed(() => route.query.code === GITLAB_TOKEN_EXPIRED_ERROR_CODE)
 
 const errorMessage = computed(() => {
+  if (isGitLabTokenExpired.value) {
+    return t('studio.publish.gitlabTokenExpiredDescription')
+  }
+
   return (route.query.error as string) || t('studio.notifications.error.unknown')
+})
+
+const alertTitle = computed(() => {
+  if (isGitLabTokenExpired.value) {
+    return t('studio.publish.gitlabTokenExpiredTitle')
+  }
+
+  return t('studio.publish.errorTitle', { providerName: gitProvider.name })
 })
 
 const repositoryInfo = computed(() => gitProvider.api.getRepositoryInfo())
 
 async function retry() {
   await router.push('/review')
+}
+
+function signOut() {
+  fetch('/__nuxt_studio/auth/session', { method: 'delete' }).then(() => {
+    host.app.unregisterServiceWorker()
+    window.location.reload()
+  })
 }
 </script>
 
@@ -66,14 +88,23 @@ async function retry() {
 
       <UAlert
         icon="i-lucide-alert-triangle"
-        :title="$t('studio.publish.errorTitle', { providerName: gitProvider.name })"
+        :title="alertTitle"
         :description="errorMessage"
         color="error"
         variant="soft"
       />
 
-      <div class="flex justify-center h-7">
+      <div class="flex justify-center gap-2 h-7">
         <UButton
+          v-if="isGitLabTokenExpired"
+          icon="i-lucide-log-out"
+          color="primary"
+          @click="signOut"
+        >
+          {{ $t('studio.buttons.signOut') }}
+        </UButton>
+        <UButton
+          v-else
           icon="i-lucide-rotate-ccw"
           @click="retry"
         >

--- a/src/app/src/utils/providers/gitlab-errors.ts
+++ b/src/app/src/utils/providers/gitlab-errors.ts
@@ -1,0 +1,52 @@
+export const GITLAB_TOKEN_EXPIRED_ERROR_CODE = 'gitlab_token_expired'
+
+export class GitLabTokenExpiredError extends Error {
+  readonly code = GITLAB_TOKEN_EXPIRED_ERROR_CODE
+
+  constructor() {
+    super('GitLab token expired')
+    this.name = 'GitLabTokenExpiredError'
+  }
+}
+
+interface GitLabOAuthErrorResponse {
+  error?: string
+  error_description?: string
+}
+
+function getGitLabOAuthErrorData(error: unknown): GitLabOAuthErrorResponse | undefined {
+  if (!error || typeof error !== 'object' || !('data' in error)) {
+    return undefined
+  }
+
+  const data = (error as { data?: unknown }).data
+
+  if (!data || typeof data !== 'object') {
+    return undefined
+  }
+
+  return data as GitLabOAuthErrorResponse
+}
+
+/**
+ * GitLab returns OAuth-style errors for expired access tokens.
+ *
+ * @see https://github.com/nuxt-content/nuxt-studio/issues/512
+ */
+export function isGitLabTokenExpiredFetchError(error: unknown): boolean {
+  if (!error || typeof error !== 'object' || !('status' in error)) {
+    return false
+  }
+
+  const status = (error as { status?: number }).status
+
+  if (status !== 401) {
+    return false
+  }
+
+  return getGitLabOAuthErrorData(error)?.error === 'invalid_token'
+}
+
+export function isGitLabTokenExpiredError(error: unknown): error is GitLabTokenExpiredError {
+  return error instanceof GitLabTokenExpiredError
+}

--- a/src/app/src/utils/providers/gitlab.ts
+++ b/src/app/src/utils/providers/gitlab.ts
@@ -4,6 +4,7 @@ import { consola } from 'consola'
 import type { GitOptions, GitProviderAPI, GitFile, RawFile, CommitResult, CommitFilesOptions } from '../../types'
 import { DraftStatus } from '../../types/draft'
 import { StudioFeature } from '../../types'
+import { GitLabTokenExpiredError, isGitLabTokenExpiredFetchError } from './gitlab-errors'
 
 const logger = consola.withTag('Nuxt Studio')
 
@@ -153,21 +154,30 @@ export function createGitLabProvider(options: GitOptions): GitProviderAPI {
       }
     })
 
-    const commitData = await $api(`/repository/commits`, {
-      method: 'POST',
-      body: {
-        branch,
-        commit_message: message,
-        actions,
-        author_name: authorName,
-        author_email: authorEmail,
-      },
-    })
+    try {
+      const commitData = await $api(`/repository/commits`, {
+        method: 'POST',
+        body: {
+          branch,
+          commit_message: message,
+          actions,
+          author_name: authorName,
+          author_email: authorEmail,
+        },
+      })
 
-    return {
-      success: true,
-      commitSha: commitData.id,
-      url: `${normalizedInstanceUrl}/${owner}/${repo}/-/commit/${commitData.id}`,
+      return {
+        success: true,
+        commitSha: commitData.id,
+        url: `${normalizedInstanceUrl}/${owner}/${repo}/-/commit/${commitData.id}`,
+      }
+    }
+    catch (error) {
+      if (isGitLabTokenExpiredFetchError(error)) {
+        throw new GitLabTokenExpiredError()
+      }
+
+      throw error
     }
   }
 

--- a/src/app/test/unit/utils/providers/gitlab.test.ts
+++ b/src/app/test/unit/utils/providers/gitlab.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DraftStatus } from '../../../../src/types/draft'
 import { createGitLabProvider } from '../../../../src/utils/providers/gitlab'
+import { GitLabTokenExpiredError } from '../../../../src/utils/providers/gitlab-errors'
 
 function createCommitsApiHandler() {
   return (
@@ -16,11 +17,16 @@ function createCommitsApiHandler() {
 
 const mock$api = vi.fn(createCommitsApiHandler())
 
-vi.mock('ofetch', () => ({
-  ofetch: {
-    create: vi.fn(() => mock$api),
-  },
-}))
+vi.mock('ofetch', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('ofetch')>()
+
+  return {
+    ...actual,
+    ofetch: {
+      create: vi.fn(() => mock$api),
+    },
+  }
+})
 
 const baseGitOptions = {
   provider: 'gitlab' as const,
@@ -170,6 +176,23 @@ describe('createGitLabProvider / commitFiles', () => {
         encoding: 'base64',
       },
     ])
+  })
+
+  it('throws GitLabTokenExpiredError when GitLab returns invalid_token', async () => {
+    mock$api.mockRejectedValueOnce({
+      status: 401,
+      data: {
+        error: 'invalid_token',
+        error_description: 'Token is expired. You can either do re-authorization or token refresh.',
+      },
+    })
+
+    const provider = createGitLabProvider({ ...baseGitOptions })
+
+    await expect(provider.commitFiles(
+      [{ path: 'content/index.md', status: DraftStatus.Created, content: '# Hello', encoding: 'utf-8' }],
+      'docs: welcome',
+    )).rejects.toBeInstanceOf(GitLabTokenExpiredError)
   })
 
   it('does not call the API when token is missing', async () => {


### PR DESCRIPTION
If we detect a 401 token expired for GitLab provider when trying to publish a commit, display a little explicit non-technical info that tells the user to logout/login with GitLab.

Currently, this is easier to do that until we can properly implement refresh_token.

See https://github.com/nuxt-content/nuxt-studio/issues/512