### PR TITLE
feat(tiptap): upload images pasted or dropped into the editor body

### DIFF
--- a/src/app/src/components/content/editor/ContentEditorTipTap.vue
+++ b/src/app/src/components/content/editor/ContentEditorTipTap.vue
@@ -4,13 +4,16 @@ import type { JSONContent } from '@tiptap/vue-3'
 import type { ComarkTree } from 'comark'
 import type { DraftItem, DatabasePageItem } from '../../../types'
 import { ref, watch, computed } from 'vue'
+import { withLeadingSlash } from 'ufo'
 import { useStudio } from '../../../composables/useStudio'
 import { useStudioState } from '../../../composables/useStudioState'
+import { useDraftMedias } from '../../../composables/useDraftMedias'
 import { comarkToTiptap } from '../../../utils/tiptap/comarkToTiptap'
 import { tiptapToComark } from '../../../utils/tiptap/tiptapToComark'
 import { removeLastEmptyParagraph } from '../../../utils/tiptap/editor'
 import { pickInitialSlot } from '../../../utils/tiptap/handlers'
 import { studioStarterKitOptions, createStudioExtensions } from '../../../utils/tiptap/studio-extensions'
+import { getFileExtension, slugifyFileName } from '../../../utils/file'
 import TiptapSpanStylePopover from '../../tiptap/TiptapSpanStylePopover.vue'
 import TiptapTableGrips from '../../tiptap/TiptapTableGrips.vue'
 import { useTiptapEditor } from '../../../composables/useTiptapEditor'
@@ -26,10 +29,28 @@ const props = defineProps({
 
 const document = defineModel<DatabasePageItem>()
 
-const { host } = useStudio()
+const { host, gitProvider } = useStudio()
 const { preferences } = useStudioState()
 
 const hasNuxtUI = host.meta.editor.components.hasNuxtUI
+
+// Upload pipeline for images pasted/dropped directly into the editor body.
+// Reuses the media draft store (base64 → IndexedDB → committed on Publish); the
+// service worker serves the draft media so the preview works immediately.
+const draftMedias = useDraftMedias(host, gitProvider)
+
+async function uploadImage(file: File): Promise<string | undefined> {
+  // Clipboard images often arrive without a usable name; derive the extension from
+  // the MIME type and give every upload a unique, collision-proof name.
+  const mimeExt = (file.type.split('/')[1] || 'png').replace('svg+xml', 'svg').replace('jpeg', 'jpg')
+  const extension = file.name.includes('.') ? getFileExtension(file.name) : mimeExt
+  const uniqueName = `${crypto.randomUUID()}.${extension}`
+
+  const renamed = new File([file], uniqueName, { type: file.type })
+  await draftMedias.upload('/', renamed)
+
+  return withLeadingSlash(slugifyFileName(uniqueName))
+}
 
 const {
   customHandlers,
@@ -159,6 +180,7 @@ watch(() => `${document.value?.id}-${props.draftItem.version}-${props.draftItem.
         placeholder: $t('studio.tiptap.editor.placeholder'),
         hasNuxtUI,
         resolveInitialSlot: tag => pickInitialSlot(host.meta.editor.components.get().find(c => c.name === tag)?.meta.slots),
+        uploadImage,
         additionalExtensions: aiExtensions,
       })"
     >

--- a/src/app/src/utils/tiptap/extensions/image-upload.ts
+++ b/src/app/src/utils/tiptap/extensions/image-upload.ts
@@ -1,0 +1,97 @@
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+
+export interface ImageUploadOptions {
+  /**
+   * Uploads a pasted/dropped image file through Studio's media pipeline and resolves
+   * to the path to reference it by (e.g. `/paste-xxxx.png`). When omitted, the
+   * extension is inert and paste/drop fall back to the editor's default behavior
+   * (this is the case in tests, where no media host is available).
+   */
+  uploadImage?: (file: File) => Promise<string | undefined>
+}
+
+function getImageFiles(fileList: FileList | undefined | null): File[] {
+  if (!fileList?.length) {
+    return []
+  }
+  return Array.from(fileList).filter(file => file.type.startsWith('image/'))
+}
+
+/**
+ * Wires the editor's clipboard paste and file drop to Studio's media upload pipeline.
+ *
+ * Without this, pasting an image does nothing and dropping an image file just makes the
+ * browser navigate to it. Here we intercept image files, push them through `uploadImage`
+ * (backed by `useDraftMedias.upload`), and insert the editor's `image` node pointing at
+ * the uploaded path. The service worker serves the draft media so the preview works
+ * immediately, and the file is committed alongside the markdown on Publish.
+ */
+export const ImageUpload = Extension.create<ImageUploadOptions>({
+  name: 'imageUpload',
+
+  addOptions() {
+    return {
+      uploadImage: undefined,
+    }
+  },
+
+  addProseMirrorPlugins() {
+    const editor = this.editor
+    const uploadImage = this.options.uploadImage
+
+    // Inert when no upload handler is provided.
+    if (!uploadImage) {
+      return []
+    }
+
+    // Paste/drop handlers must return synchronously, so the upload + insert runs detached.
+    async function insertImages(files: File[], pos?: number) {
+      let insertAt = pos
+      for (const file of files) {
+        const src = await uploadImage!(file)
+        if (!src) {
+          continue
+        }
+
+        const node = { type: 'image', attrs: { props: { src } } }
+
+        if (typeof insertAt === 'number') {
+          editor.chain().focus().insertContentAt(insertAt, node).run()
+          // Advance so multiple files don't stack on the same position.
+          insertAt += 1
+        }
+        else {
+          editor.chain().focus().insertContent(node).run()
+        }
+      }
+    }
+
+    return [
+      new Plugin({
+        key: new PluginKey('imageUpload'),
+        props: {
+          handlePaste(_view, event) {
+            const files = getImageFiles(event.clipboardData?.files)
+            if (!files.length) {
+              return false
+            }
+            event.preventDefault()
+            void insertImages(files)
+            return true
+          },
+          handleDrop(view, event) {
+            const files = getImageFiles(event.dataTransfer?.files)
+            if (!files.length) {
+              return false
+            }
+            event.preventDefault()
+            const coords = view.posAtCoords({ left: event.clientX, top: event.clientY })
+            void insertImages(files, coords?.pos)
+            return true
+          },
+        },
+      }),
+    ]
+  },
+})

--- a/src/app/src/utils/tiptap/studio-extensions.ts
+++ b/src/app/src/utils/tiptap/studio-extensions.ts
@@ -9,6 +9,7 @@ import { Frontmatter } from './extensions/frontmatter'
 import { Image } from './extensions/image'
 import { ImagePicker } from './extensions/image-picker'
 import { CodeAttributes } from './extensions/code-attributes'
+import { ImageUpload } from './extensions/image-upload'
 import { InlineElement } from './extensions/inline-element'
 import { Slot } from './extensions/slot'
 import { SlotDropGuard } from './extensions/slot-drop-guard'
@@ -28,6 +29,7 @@ interface CreateStudioExtensionsOptions {
   placeholder?: string
   hasNuxtUI?: boolean
   resolveInitialSlot?: (tag: string) => string | undefined
+  uploadImage?: (file: File) => Promise<string | undefined>
   additionalExtensions?: AnyExtension[]
 }
 
@@ -35,12 +37,14 @@ export function createStudioExtensions({
   placeholder = '',
   hasNuxtUI = true,
   resolveInitialSlot,
+  uploadImage,
   additionalExtensions = [],
 }: CreateStudioExtensionsOptions = {}): AnyExtension[] {
   return [
     CodeAttributes,
     CustomPlaceholder.configure({ placeholder }),
     Frontmatter,
+    ImageUpload.configure({ uploadImage }),
     Image,
     ImagePicker,
     VideoPicker,


### PR DESCRIPTION
Wire the rich editor's paste and drop events to Studio's existing media draft pipeline. Image files pasted from the clipboard or dropped onto the editor body now upload into public/ with a UUID filename (via useDraftMedias.upload) and insert an image node pointing at the uploaded path.

Previously paste did nothing and dropping a file made the browser navigate to it.


- Copy-paste

  https://github.com/user-attachments/assets/2fa7eb31-5701-4fc0-bed3-971fe666c6f9

- Drag to upload

  https://github.com/user-attachments/assets/02b8ee3c-d832-4c5d-bdf1-a25a60177e70