### PR TITLE
fix(document): unwrap array/object :key props when rendering dump-read bodies

### DIFF
--- a/src/app/test/integration/component-array-props-roundtrip.test.ts
+++ b/src/app/test/integration/component-array-props-roundtrip.test.ts
@@ -2,20 +2,9 @@ import { test, describe, expect } from 'vitest'
 import { contentFromDocument } from '../../../module/dist/runtime/utils/document'
 import { createMockDocument } from '../mocks/document'
 
-// When @nuxt/content (@nuxtjs/mdc) parses a component with array props declared as
-// YAML frontmatter, e.g.
-//
-//   ::foo
-//   ---
-//   bar:
-//     - baz
-//   ---
-//   ::
-//
-// it stores the array as a colon-bound, JSON-stringified prop: { ":bar": "[\"baz\"]" }.
-// Studio renders that deployed body back to Markdown for the "Website" side of its
-// conflict diff (contentFromDocument). It must reproduce the original source, but it
-// does not round-trip the array prop, producing a permanent conflict against the repo.
+// @nuxtjs/mdc stores a component's YAML-block array/object prop as a colon-bound,
+// JSON-stringified attr: { ":bar": "[\"baz\"]" }. Rendering that deployed body back
+// to Markdown must reproduce the original YAML block, not a permanent conflict.
 describe('component array props are not round-tripped from the deployed body shape', () => {
   test('array of primitives', async () => {
     const deployedBody = {
@@ -120,9 +109,8 @@ describe('component array props are not round-tripped from the deployed body sha
   })
 
   test('scalar ":" binding stays an inline binding (not unwrapped to a block)', async () => {
-    // Only array/object ':'-bindings are @nuxtjs/mdc block artifacts. A scalar
-    // binding (`:width="200"`) is a genuine comark inline binding that comark
-    // round-trips on its own — stripping its colon would drop the binding.
+    // Scalar ':' bindings are genuine comark inline bindings, not mdc artifacts —
+    // stripping the colon would drop the binding.
     const deployedBody = {
       nodes: [
         ['foo', { ':width': '200', 'color': 'secondary' }],

--- a/src/app/test/integration/component-array-props-roundtrip.test.ts
+++ b/src/app/test/integration/component-array-props-roundtrip.test.ts
@@ -1,0 +1,69 @@
+import { test, describe, expect } from 'vitest'
+import { contentFromDocument } from '../../../module/dist/runtime/utils/document'
+import { createMockDocument } from '../mocks/document'
+
+// When @nuxt/content (@nuxtjs/mdc) parses a component with array props declared as
+// YAML frontmatter, e.g.
+//
+//   ::foo
+//   ---
+//   bar:
+//     - baz
+//   ---
+//   ::
+//
+// it stores the array as a colon-bound, JSON-stringified prop: { ":bar": "[\"baz\"]" }.
+// Studio renders that deployed body back to Markdown for the "Website" side of its
+// conflict diff (contentFromDocument). It must reproduce the original source, but it
+// does not round-trip the array prop, producing a permanent conflict against the repo.
+describe('component array props are not round-tripped from the deployed body shape', () => {
+  test('array of primitives', async () => {
+    const deployedBody = {
+      nodes: [
+        ['foo', { ':bar': '["baz"]' }],
+      ],
+      frontmatter: {},
+      meta: {},
+    }
+
+    const document = createMockDocument('docs/index.md', { body: deployedBody })
+
+    const expected = [
+      '::foo',
+      '---',
+      'bar:',
+      '  - baz',
+      '---',
+      '::',
+      '',
+    ].join('\n')
+
+    expect(await contentFromDocument(document)).toBe(expected)
+  })
+
+  test('array of objects (complex)', async () => {
+    const deployedBody = {
+      nodes: [
+        ['foo', { ':bar': '[{"baz":"qux","quux":"corge"},{"baz":"grault"}]' }],
+      ],
+      frontmatter: {},
+      meta: {},
+    }
+
+    const document = createMockDocument('docs/index.md', { body: deployedBody })
+
+    const expected = [
+      '::foo',
+      '---',
+      'bar:',
+      '  - baz: qux',
+      '    quux: corge',
+      '  - baz: grault',
+      '---',
+      '::',
+      '',
+    ].join('\n')
+
+    expect(await contentFromDocument(document)).toBe(expected)
+  })
+})

--- a/src/app/test/integration/component-array-props-roundtrip.test.ts
+++ b/src/app/test/integration/component-array-props-roundtrip.test.ts
@@ -66,4 +66,75 @@ describe('component array props are not round-tripped from the deployed body sha
 
     expect(await contentFromDocument(document)).toBe(expected)
   })
+
+  test('object prop', async () => {
+    const deployedBody = {
+      nodes: [
+        ['foo', { ':bar': '{"baz":"qux","quux":"corge"}' }],
+      ],
+      frontmatter: {},
+      meta: {},
+    }
+
+    const document = createMockDocument('docs/index.md', { body: deployedBody })
+
+    const expected = [
+      '::foo',
+      '---',
+      'bar:',
+      '  baz: qux',
+      '  quux: corge',
+      '---',
+      '::',
+      '',
+    ].join('\n')
+
+    expect(await contentFromDocument(document)).toBe(expected)
+  })
+
+  test('nested component with an array prop', async () => {
+    // unbindComarkTree must recurse into children, not just top-level nodes.
+    const deployedBody = {
+      nodes: [
+        ['outer', {}, ['inner', { ':bar': '["baz"]' }]],
+      ],
+      frontmatter: {},
+      meta: {},
+    }
+
+    const document = createMockDocument('docs/index.md', { body: deployedBody })
+
+    const expected = [
+      '::outer',
+      '  :::inner',
+      '  ---',
+      '  bar:',
+      '    - baz',
+      '  ---',
+      '  :::',
+      '::',
+      '',
+    ].join('\n')
+
+    expect(await contentFromDocument(document)).toBe(expected)
+  })
+
+  test('scalar ":" binding stays an inline binding (not unwrapped to a block)', async () => {
+    // Only array/object ':'-bindings are @nuxtjs/mdc block artifacts. A scalar
+    // binding (`:width="200"`) is a genuine comark inline binding that comark
+    // round-trips on its own — stripping its colon would drop the binding.
+    const deployedBody = {
+      nodes: [
+        ['foo', { ':width': '200', 'color': 'secondary' }],
+      ],
+      frontmatter: {},
+      meta: {},
+    }
+
+    const document = createMockDocument('docs/index.md', { body: deployedBody })
+
+    const expected = '::foo{:width="200" color="secondary"}\n::\n'
+
+    expect(await contentFromDocument(document)).toBe(expected)
+  })
 })

--- a/src/module/src/runtime/utils/document/generate.ts
+++ b/src/module/src/runtime/utils/document/generate.ts
@@ -12,6 +12,7 @@ import yaml from 'js-yaml'
 import { useHostMeta } from '../../composables/useMeta'
 import { addPageTypeFields, generateStemFromId, getFileExtension } from './utils'
 import { cleanDataKeys } from './schema'
+import { unbindComarkTree } from './legacy'
 
 const logger = consola.withTag('Nuxt Studio')
 
@@ -155,7 +156,8 @@ export async function contentFromJSONDocument(document: DatabaseItem): Promise<s
 }
 
 export async function contentFromMarkdownDocument(document: DatabaseItem): Promise<string | null> {
-  const markdown = await renderMarkdown(document.body as unknown as ComarkTree, {
+  const body = unbindComarkTree(document.body as unknown as ComarkTree)
+  const markdown = await renderMarkdown(body, {
     blockAttributesStyle: 'frontmatter',
     components: {
       br: () => ':br',

--- a/src/module/src/runtime/utils/document/legacy.ts
+++ b/src/module/src/runtime/utils/document/legacy.ts
@@ -12,7 +12,6 @@
  *      - compare.ts   → update toMarkdownRoot helper to compare ComarkTrees directly
  *      - index.ts     → remove re-exports of comarkTreeFromLegacyDocument and markdownRootFromComarkTree
  *      - generate.ts  → remove unbindComarkTree usage in contentFromMarkdownDocument
- *                       (a comark-native body has no ':key' JSON bindings to strip)
  */
 
 import type { MarkdownRoot } from '@nuxt/content'
@@ -340,12 +339,9 @@ function propsMDCToComark(tag: string, props: Record<string, unknown>): Record<s
     next = rest
   }
 
-  // Token-list attrs (class, ping, accept, …) come out of @nuxtjs/mdc as
-  // arrays but as space-joined strings from comark's parser. Collapse any
-  // remaining arrays of primitives so the bridged body matches comark's shape.
-  // Skip keys that were unwrapped from a ':' binding — those are genuine data
-  // arrays (e.g. `:tags='["a","b"]'`) that must stay arrays so comark renders
-  // them as a YAML block, not a space-joined inline string.
+  // Token-list attrs (class, ping, accept, …) come from @nuxtjs/mdc as arrays but
+  // as space-joined strings from comark — collapse to match. Skip ':' bindings:
+  // those are genuine data arrays comark must render as YAML blocks, not inline.
   for (const key in next) {
     if (unboundKeys.has(key)) continue
     const value = next[key]
@@ -358,13 +354,10 @@ function propsMDCToComark(tag: string, props: Record<string, unknown>): Record<s
 }
 
 /**
- * Unwrap @nuxtjs/mdc's ':key' + JSON-string encoding for arrays/objects to plain
- * comark values, e.g. `{ ':bar': '["baz"]' }` → `{ bar: ['baz'] }`.
- *
- * Booleans keep the ':' prefix — comarkAttributes needs it to emit `key` not
- * `key="true"`. Returns the rewritten props alongside the set of keys that were
- * unwrapped from a binding, so callers can avoid further mangling them (the
- * token-list collapse in `propsMDCToComark` must not touch genuine data arrays).
+ * Unwrap @nuxtjs/mdc's ':key' + JSON-string array/object bindings to plain comark
+ * values (`{ ':bar': '["baz"]' }` → `{ bar: ['baz'] }`). Booleans keep the ':' so
+ * comarkAttributes emits `key` not `key="true"`. The returned `unbound` set marks
+ * rewritten keys so the token-list collapse won't re-mangle genuine data arrays.
  */
 function unbindMDCProps(props: Record<string, unknown>): { props: Record<string, unknown>, unbound: Set<string> } {
   const next: Record<string, unknown> = {}
@@ -394,21 +387,11 @@ function unbindMDCProps(props: Record<string, unknown>): { props: Record<string,
 }
 
 /**
- * Recursively unwrap @nuxtjs/mdc ':key' JSON-binding artifacts for array/object
- * props in a ComarkTree's element attrs, turning them into real comark values.
- *
- * Needed at the render boundary: a body already in comark shape (read straight
- * from the dump without passing through the MDC→Comark bridge) can carry an
- * array/object prop authored as a YAML block but encoded by @nuxtjs/mdc as a
- * ':key' + JSON string. comark's renderer would otherwise emit it as an inline
- * string literal (`::foo{:bar="[...]"}`) instead of a YAML block — producing a
- * permanent phantom conflict against the repo.
- *
- * Only array/object bindings are touched. Scalar bindings (`:width="200"`,
- * `:reverse="true"`) are genuine comark inline bindings that comark round-trips
- * faithfully on its own — stripping their colon would drop the binding. A
- * properly bridged or comark-native body has no array/object ':key' artifacts,
- * so this is a no-op there.
+ * Strip @nuxtjs/mdc ':key' JSON-binding artifacts from array/object attrs in a
+ * comark-shaped body read straight from the dump (no MDC→Comark bridge). Without
+ * this, comark renders such a prop as an inline `{:bar="[...]"}` literal instead of
+ * a YAML block, producing a permanent phantom conflict. Scalar bindings are left
+ * alone — comark round-trips those itself; stripping the colon would drop them.
  */
 export function unbindComarkTree(tree: ComarkTree): ComarkTree {
   return { ...tree, nodes: tree.nodes.map(unbindComarkNode) }
@@ -417,8 +400,7 @@ export function unbindComarkTree(tree: ComarkTree): ComarkTree {
 function unbindComarkNode(node: ComarkNode): ComarkNode {
   if (!Array.isArray(node)) return node
   const [tag, attrs, ...children] = node as ComarkElement | ComarkComment
-  // Comments ([null, {}, value]) carry no bindable attrs.
-  if (tag === null) return node
+  if (tag === null) return node // comments carry no bindable attrs
   return [
     tag,
     unbindMDCBlockProps((attrs as Record<string, unknown>) || {}),
@@ -438,7 +420,7 @@ function unbindMDCBlockProps(props: Record<string, unknown>): Record<string, unk
         }
       }
       catch {
-        // fall through — leave the prop untouched
+        // not JSON — leave untouched
       }
     }
     next[rawKey] = value

--- a/src/module/src/runtime/utils/document/legacy.ts
+++ b/src/module/src/runtime/utils/document/legacy.ts
@@ -11,6 +11,8 @@
  *                       remove markdownRootFromComarkTree usage in db.upsert
  *      - compare.ts   → update toMarkdownRoot helper to compare ComarkTrees directly
  *      - index.ts     → remove re-exports of comarkTreeFromLegacyDocument and markdownRootFromComarkTree
+ *      - generate.ts  → remove unbindComarkTree usage in contentFromMarkdownDocument
+ *                       (a comark-native body has no ':key' JSON bindings to strip)
  */
 
 import type { MarkdownRoot } from '@nuxt/content'
@@ -310,31 +312,8 @@ function normalizeMdcChildren(children: MDCNode[]): MDCNode[] {
  *   We'll add a proper configurable surface for this later.
  */
 function propsMDCToComark(tag: string, props: Record<string, unknown>): Record<string, unknown> {
-  let next: Record<string, unknown> = props
-
-  // Unwrap @nuxtjs/mdc's ':key' + JSON-string encoding for arrays/objects to plain values.
-  // Booleans keep the ':' prefix — comarkAttributes needs it to emit `key` not `key="true"`.
-  const unbound: Record<string, unknown> = {}
-  for (const [rawKey, value] of Object.entries(next)) {
-    if (rawKey.startsWith(':') && typeof value === 'string') {
-      try {
-        const parsed = JSON.parse(value)
-        if (typeof parsed === 'boolean') {
-          unbound[rawKey] = value
-        }
-        else {
-          unbound[rawKey.slice(1)] = parsed
-        }
-      }
-      catch {
-        unbound[rawKey] = value
-      }
-    }
-    else {
-      unbound[rawKey] = value
-    }
-  }
-  next = unbound
+  const { props: unbound, unbound: unboundKeys } = unbindMDCProps(props)
+  let next: Record<string, unknown> = unbound
 
   if (tag === 'template') {
     const vSlotKey = Object.keys(next).find(k => k.startsWith('v-slot:'))
@@ -364,13 +343,106 @@ function propsMDCToComark(tag: string, props: Record<string, unknown>): Record<s
   // Token-list attrs (class, ping, accept, …) come out of @nuxtjs/mdc as
   // arrays but as space-joined strings from comark's parser. Collapse any
   // remaining arrays of primitives so the bridged body matches comark's shape.
+  // Skip keys that were unwrapped from a ':' binding — those are genuine data
+  // arrays (e.g. `:tags='["a","b"]'`) that must stay arrays so comark renders
+  // them as a YAML block, not a space-joined inline string.
   for (const key in next) {
+    if (unboundKeys.has(key)) continue
     const value = next[key]
     if (Array.isArray(value) && value.every(v => typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')) {
       next[key] = value.join(' ')
     }
   }
 
+  return next
+}
+
+/**
+ * Unwrap @nuxtjs/mdc's ':key' + JSON-string encoding for arrays/objects to plain
+ * comark values, e.g. `{ ':bar': '["baz"]' }` → `{ bar: ['baz'] }`.
+ *
+ * Booleans keep the ':' prefix — comarkAttributes needs it to emit `key` not
+ * `key="true"`. Returns the rewritten props alongside the set of keys that were
+ * unwrapped from a binding, so callers can avoid further mangling them (the
+ * token-list collapse in `propsMDCToComark` must not touch genuine data arrays).
+ */
+function unbindMDCProps(props: Record<string, unknown>): { props: Record<string, unknown>, unbound: Set<string> } {
+  const next: Record<string, unknown> = {}
+  const unbound = new Set<string>()
+  for (const [rawKey, value] of Object.entries(props)) {
+    if (rawKey.startsWith(':') && typeof value === 'string') {
+      try {
+        const parsed = JSON.parse(value)
+        if (typeof parsed === 'boolean') {
+          next[rawKey] = value
+        }
+        else {
+          const key = rawKey.slice(1)
+          next[key] = parsed
+          unbound.add(key)
+        }
+      }
+      catch {
+        next[rawKey] = value
+      }
+    }
+    else {
+      next[rawKey] = value
+    }
+  }
+  return { props: next, unbound }
+}
+
+/**
+ * Recursively unwrap @nuxtjs/mdc ':key' JSON-binding artifacts for array/object
+ * props in a ComarkTree's element attrs, turning them into real comark values.
+ *
+ * Needed at the render boundary: a body already in comark shape (read straight
+ * from the dump without passing through the MDC→Comark bridge) can carry an
+ * array/object prop authored as a YAML block but encoded by @nuxtjs/mdc as a
+ * ':key' + JSON string. comark's renderer would otherwise emit it as an inline
+ * string literal (`::foo{:bar="[...]"}`) instead of a YAML block — producing a
+ * permanent phantom conflict against the repo.
+ *
+ * Only array/object bindings are touched. Scalar bindings (`:width="200"`,
+ * `:reverse="true"`) are genuine comark inline bindings that comark round-trips
+ * faithfully on its own — stripping their colon would drop the binding. A
+ * properly bridged or comark-native body has no array/object ':key' artifacts,
+ * so this is a no-op there.
+ */
+export function unbindComarkTree(tree: ComarkTree): ComarkTree {
+  return { ...tree, nodes: tree.nodes.map(unbindComarkNode) }
+}
+
+function unbindComarkNode(node: ComarkNode): ComarkNode {
+  if (!Array.isArray(node)) return node
+  const [tag, attrs, ...children] = node as ComarkElement | ComarkComment
+  // Comments ([null, {}, value]) carry no bindable attrs.
+  if (tag === null) return node
+  return [
+    tag,
+    unbindMDCBlockProps((attrs as Record<string, unknown>) || {}),
+    ...(children as ComarkNode[]).map(unbindComarkNode),
+  ] as ComarkElement
+}
+
+function unbindMDCBlockProps(props: Record<string, unknown>): Record<string, unknown> {
+  const next: Record<string, unknown> = {}
+  for (const [rawKey, value] of Object.entries(props)) {
+    if (rawKey.startsWith(':') && typeof value === 'string') {
+      try {
+        const parsed = JSON.parse(value)
+        if (parsed !== null && typeof parsed === 'object') {
+          next[rawKey.slice(1)] = parsed
+          continue
+        }
+      }
+      catch {
+        // fall through — leave the prop untouched
+      }
+    }
+    next[rawKey] = value
+  }
   return next
 }
 

--- a/src/module/test/utils/legacy.test.ts
+++ b/src/module/test/utils/legacy.test.ts
@@ -660,10 +660,8 @@ describe('mdc → comark generic array → string normalization', () => {
   })
 
   it('keeps a primitive array unwrapped from a ":" binding as an array (does not collapse to a string)', async () => {
-    // A YAML-block array-of-primitives prop is serialised by @nuxtjs/mdc as a
-    // ':key' + JSON string. Unlike a bare token-list array (className, ping),
-    // it is genuine data and must survive as an array so comark renders it as a
-    // YAML block — collapsing it to `tags="a b"` would diverge from the repo.
+    // Unlike a token-list array (className, ping), a ':'-bound array is genuine
+    // data — it must stay an array so comark renders a YAML block, not `tags="a b"`.
     const tree = comarkTreeFromLegacyDocument(legacyDocument({
       type: 'root',
       children: [{

--- a/src/module/test/utils/legacy.test.ts
+++ b/src/module/test/utils/legacy.test.ts
@@ -658,6 +658,31 @@ describe('mdc → comark generic array → string normalization', () => {
     const card = tree.nodes[0] as [string, Record<string, unknown>, ...unknown[]]
     expect(card[1]).toEqual({ items: [{ x: 1 }] })
   })
+
+  it('keeps a primitive array unwrapped from a ":" binding as an array (does not collapse to a string)', async () => {
+    // A YAML-block array-of-primitives prop is serialised by @nuxtjs/mdc as a
+    // ':key' + JSON string. Unlike a bare token-list array (className, ping),
+    // it is genuine data and must survive as an array so comark renders it as a
+    // YAML block — collapsing it to `tags="a b"` would diverge from the repo.
+    const tree = comarkTreeFromLegacyDocument(legacyDocument({
+      type: 'root',
+      children: [{
+        type: 'element',
+        tag: 'card',
+        props: { ':tags': '["a","b"]' },
+        children: [],
+      }],
+    }))!
+
+    const card = tree.nodes[0] as [string, Record<string, unknown>, ...unknown[]]
+    expect(card[1]).toEqual({ tags: ['a', 'b'] })
+
+    const markdown = await renderMarkdown(tree, { blockAttributesStyle: 'frontmatter' })
+    expect(markdown).toContain('tags:')
+    expect(markdown).toContain('- a')
+    expect(markdown).toContain('- b')
+    expect(markdown).not.toContain('tags="a b"')
+  })
 })
 
 describe('mdc → comark `rel` stripping', () => {


### PR DESCRIPTION
## Issue

A component with an array/object prop authored as a YAML block:

```md
::foo
---
bar:
  - baz
---
::
```

shows a permanent, un-resolvable **Conflict Detected** diff — even without editing. The "Website" (deployed) side never serializes back to the committed source.

## Root cause

`@nuxtjs/mdc` stores such a prop as a colon-bound, JSON-stringified attr: `{ ":bar": "[\"baz\"]" }`. #485 / #502 already unwrap this — but only in `propsMDCToComark`, i.e. on the **MDC→Comark bridge** (the edit/save path).

The conflict diff renders the body **read straight from the dump**, already in comark shape, which never passes through that bridge. So the `:key` artifact survives and comark emits it inline (`{:bar="[...]"}`) instead of as a YAML block — never matching the source.

## Fix

Apply the same unwrap at the render boundary (`contentFromMarkdownDocument`, via `unbindComarkTree`): unwrap array/object `:key` bindings to real comark values before rendering. Scalar bindings (`:width="200"`) are left untouched — those are genuine comark inline bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)