### PR TITLE
feat(comark): disable comark linkify

### DIFF
--- a/src/app/src/utils/ai/completion.ts
+++ b/src/app/src/utils/ai/completion.ts
@@ -236,7 +236,7 @@ export async function tiptapSliceToMarkdown(
  */
 export async function markdownSliceToTiptap(markdown: string): Promise<JSONContent[]> {
   // Parse markdown to ComarkTree
-  const tree = await parse(markdown)
+  const tree = await parse(markdown, { linkify: false })
 
   // Convert ComarkTree directly to TipTap JSON
   const tiptapDoc = comarkToTiptap(tree)

--- a/src/module/src/runtime/utils/document/generate.ts
+++ b/src/module/src/runtime/utils/document/generate.ts
@@ -104,6 +104,7 @@ export async function documentFromMarkdownContent(id: string, content: string, o
   const tree = await parse(content, {
     autoClose: false,
     autoUnwrap: true,
+    linkify: false,
     plugins: [
       comarkEmoji(),
       highlight({ themes }),


### PR DESCRIPTION
comark's `parse` now supports `linkify: false`. Since the editor already linkifies, pass it at both parse sites so bare URLs in content aren't auto-converted to `<a>` links at parse time.

- `generate.ts` (`documentFromMarkdownContent`) — the central markdown→tree parse
- `completion.ts` (`markdownSliceToTiptap`) — AI completion slice parse

Bumps the `comark` pin to a build that exposes the option. `linkify` is parse-only (render has none).

> [!NOTE]
> Depends on comark PR comarkdown/comark#259 — the build this pins to (`0bf3eda`) is that PR's branch, which also fixes shiki code-block round-trip regressions in comark 0.4.0. Repoint to a released comark version once #259 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)