### PR TITLE
fix(form): render select dropdowns for array of enum string items

### DIFF
--- a/src/app/src/components/form/input/InputArray.vue
+++ b/src/app/src/components/form/input/InputArray.vue
@@ -22,6 +22,18 @@ const itemsLabel = computed(() =>
   props.formItem?.title ? formItemInputLabel(props.formItem) : '',
 )
 
+const hasOptions = computed(() => props.formItem?.options && props.formItem.options.length > 0)
+
+const selectItems = computed(() => {
+  if (!props.formItem?.options) return []
+  return props.formItem.options
+    .filter(option => option !== '')
+    .map(option => ({
+      label: option,
+      value: option,
+    }))
+})
+
 const activeIndex = ref<number | null>(null)
 const stringEditingValue = ref('')
 
@@ -60,8 +72,8 @@ function addItem() {
 
   model.value = [...(model.value || []), newItem]
 
-  // Auto-focus new string item
-  if (itemsType.value === 'string') {
+  // Auto-focus new string item (skip for enum arrays — the select is always visible)
+  if (itemsType.value === 'string' && !hasOptions.value) {
     nextTick(() => {
       startStringEditing(model.value.length - 1)
     })
@@ -167,6 +179,53 @@ function moveItem(index: number, offset: number) {
             @update:model-value="updateItem(item.index, $event)"
           />
         </Collapsible>
+      </div>
+    </template>
+
+    <!-- Array of Enum Strings -->
+    <template v-else-if="itemsType === 'string' && hasOptions">
+      <div class="flex flex-col gap-1.5">
+        <div
+          v-for="item in items"
+          :key="item.index"
+          class="flex items-center gap-1 group/item"
+        >
+          <USelect
+            :model-value="(item.value as string)"
+            :items="selectItems"
+            :placeholder="$t('studio.form.text.selectPlaceholder')"
+            size="xs"
+            class="flex-1"
+            @update:model-value="updateItem(item.index, $event)"
+          />
+          <UButton
+            variant="ghost"
+            color="neutral"
+            size="2xs"
+            icon="i-lucide-arrow-up"
+            class="opacity-0 group-hover/item:opacity-100 transition-opacity"
+            :aria-label="$t('studio.form.array.moveItemUp')"
+            @click.stop="moveItem(item.index, -1)"
+          />
+          <UButton
+            variant="ghost"
+            color="neutral"
+            size="2xs"
+            icon="i-lucide-arrow-down"
+            class="opacity-0 group-hover/item:opacity-100 transition-opacity"
+            :aria-label="$t('studio.form.array.moveItemDown')"
+            @click.stop="moveItem(item.index, 1)"
+          />
+          <UButton
+            variant="ghost"
+            color="neutral"
+            size="2xs"
+            icon="i-lucide-trash"
+            class="opacity-0 group-hover/item:opacity-100 transition-opacity"
+            :aria-label="$t('studio.form.array.deleteItem')"
+            @click.stop="deleteItem(item.index)"
+          />
+        </div>
       </div>
     </template>
 


### PR DESCRIPTION
## Summary

Fixes #374

When a collection schema defines `z.array(z.enum([...]))`, the form editor now renders select dropdowns for each array item instead of falling back to free-text inputs.

The enum `options` were already correctly propagated through schema parsing (`buildFormTreeFromSchema` → `arrayItemForm`), but `InputArray.vue` ignored them when rendering string items.

### Changes

- Detect `options` on the array item's `FormItem` (same pattern as `InputText.vue`)
- Add a new template section for enum string arrays that renders `USelect` per item with reorder/delete controls
- Skip auto-focus on add for enum arrays since the selects are always visible

### Before / After

**Before:** `z.array(z.enum([...]))` → text inputs (arbitrary strings allowed)
**After:** `z.array(z.enum([...]))` → select dropdowns (constrained to enum values)