### PR TITLE
fix(tiptap): prevent backspace from wiping frontmatter content

### DIFF
--- a/src/app/src/utils/tiptap/extensions/frontmatter.ts
+++ b/src/app/src/utils/tiptap/extensions/frontmatter.ts
@@ -6,12 +6,21 @@ export interface FrontmatterOptions {
   HTMLAttributes: Record<string, unknown>
 }
 
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    Frontmatter: {
+      handleFrontmatterBackspace: () => ReturnType
+    }
+  }
+}
+
 export const Frontmatter = Node.create<FrontmatterOptions>({
   name: 'frontmatter',
   priority: 1000,
   group: 'block',
   selectable: false,
   inline: false,
+  isolating: true,
 
   addOptions() {
     return {
@@ -37,6 +46,35 @@ export const Frontmatter = Node.create<FrontmatterOptions>({
       mergeAttributes(HTMLAttributes, { 'data-type': 'Frontmatter' }),
       0,
     ]
+  },
+
+  addCommands() {
+    return {
+      handleFrontmatterBackspace: () => ({ state }) => {
+        const { selection } = state
+        if (!selection.empty) return false
+
+        const { $from } = selection
+        if ($from.parentOffset > 0 || $from.parent.type.spec.isolating) return false
+
+        for (let depth = $from.depth - 1; depth >= 0; depth--) {
+          if ($from.index(depth) > 0) {
+            return $from.node(depth).child($from.index(depth) - 1).type.name === 'frontmatter'
+          }
+          if ($from.node(depth).type.spec.isolating) return false
+        }
+        return false
+      },
+    }
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Backspace': ({ editor }) => editor.commands.handleFrontmatterBackspace(),
+      'Shift-Backspace': ({ editor }) => editor.commands.handleFrontmatterBackspace(),
+      'Mod-Backspace': ({ editor }) => editor.commands.handleFrontmatterBackspace(),
+      'Alt-Backspace': ({ editor }) => editor.commands.handleFrontmatterBackspace(),
+    }
   },
 
   addNodeView() {


### PR DESCRIPTION
## The issue

Pressing **Backspace** with the cursor at the start of the block directly below the frontmatter caused the frontmatter to flash as deleted and then **reappear with its content wiped** — silently destroying the file's frontmatter.

The frontmatter node is a content-less **atom**: all its data lives in `attrs.frontmatter` rather than in child nodes. That makes it uniquely vulnerable to this deletion path:

1. Backspace at the start of the paragraph below runs ProseMirror's default `joinBackward`. When the preceding node is an atom, `joinBackward` deletes it through a branch that **ignores `isolating`** — taking `attrs.frontmatter` with it (the "flash").
2. `tiptapToComark` then sees no frontmatter node and defaults the tree's frontmatter to `{}`.
3. The version-bump rebuild runs `comarkToTiptap`, which **unconditionally re-inserts** a frontmatter node — now empty (the "reappears blank").

## Why we can't just `return false` like `Slot` does

`Slot` solves its own backspace problem with `isolating: true` plus a `handleSlotBackspace` command that is a pure no-op (`return false`). That works for `Slot` because a slot is a **content node** — `isolating` alone is enough to stop `joinBackward` from merging across it, so the keymap only needs to exist, not to act.

The frontmatter is a content-less **atom**, and `joinBackward`'s atom-delete branch *ignores* `isolating`. A no-op handler would let that branch run and delete the node anyway. So the command can't passively defer — it has to **actively return `true`** to swallow the keystroke in exactly the case where the backspace would join across the frontmatter, while returning `false` everywhere else so normal backspace is untouched.

## The fix

Give frontmatter `isolating: true` plus a `Backspace` keymap, mirroring `Slot`'s shape — but with a real command instead of a no-op. The command reproduces ProseMirror's own `findCutBefore` walk to detect when the node the backspace would join across is the frontmatter, returns `true` to block deletion in that one case, and `false` in all others.

## Behavior

### Before
https://github.com/user-attachments/assets/cbbf4925-92b3-466a-bc8b-bbf48a570194

### After
https://github.com/user-attachments/assets/2e3cfdfc-613e-49da-89ba-c88d09e2a25c
