### PR TITLE
fix(document): upgrade legacy bodies to ComarkTree at read boundaries

### DIFF
--- a/src/app/src/composables/useDraftBase.ts
+++ b/src/app/src/composables/useDraftBase.ts
@@ -39,6 +39,18 @@ export function useDraftBase<T extends DatabaseItem | MediaItem>(
     return name as 'studio:draft:document:updated' | 'studio:draft:ai:updated' | 'studio:draft:media:updated'
   }
 
+  // Older Studio builds persisted legacy bodies (MarkdownRoot/minimark) in IndexedDB;
+  // upgrade on load so the app only sees comark.
+  function upgradeLegacyBodies(item: DraftItem): DraftItem {
+    if (type !== 'document') return item
+    const ensureComarkBody = host.document.utils.ensureComarkBody
+    return {
+      ...item,
+      modified: item.modified ? ensureComarkBody(item.modified as DatabaseItem) : item.modified,
+      original: item.original ? ensureComarkBody(item.original as DatabaseItem) : item.original,
+    }
+  }
+
   async function get(fsPath: string): Promise<DraftItem<T> | undefined> {
     return list.value.find(item => item.fsPath === fsPath) as DraftItem<T>
   }
@@ -221,7 +233,7 @@ export function useDraftBase<T extends DatabaseItem | MediaItem>(
           await storage.removeItem(key)
           return null
         }
-        return item
+        return upgradeLegacyBodies(item)
       }))
     })
 

--- a/src/app/src/types/index.ts
+++ b/src/app/src/types/index.ts
@@ -86,6 +86,8 @@ export interface StudioHost {
       isMatchingContent: (content: string, document: DatabaseItem) => Promise<boolean>
       pickReservedKeys: (document: DatabaseItem) => DatabaseItem
       cleanDataKeys: (document: DatabaseItem) => DatabaseItem
+      // Legacy compat — delete when @nuxt/content returns ComarkTree natively.
+      ensureComarkBody: (document: DatabaseItem) => DatabaseItem
       detectActives: () => Array<{ fsPath: string, title: string }>
     }
     generate: {

--- a/src/module/src/runtime/host.ts
+++ b/src/module/src/runtime/host.ts
@@ -3,7 +3,7 @@ import { ensure } from './utils/ensure'
 import type { CollectionInfo, CollectionItemBase, CollectionSource, DatabaseAdapter } from '@nuxt/content'
 import type { ContentDatabaseAdapter } from '../types/content'
 import { getCollectionByFilePath, generateIdFromFsPath, generateRecordDeletion, generateRecordInsert, generateFsPathFromId, getCollectionById } from './utils/collection'
-import { applyCollectionSchema, isDocumentMatchingContent, documentFromContent, contentFromDocument, areDocumentsEqual, pickReservedKeysFromDocument, cleanDataKeys, sanitizeDocumentTree, comarkTreeFromLegacyDocument, markdownRootFromComarkTree, isComarkTree } from './utils/document'
+import { applyCollectionSchema, isDocumentMatchingContent, documentFromContent, contentFromDocument, areDocumentsEqual, pickReservedKeysFromDocument, cleanDataKeys, sanitizeDocumentTree, markdownRootFromComarkTree, isComarkTree, ensureComarkBody } from './utils/document'
 import { getHostStyles, getSidebarWidth, adjustFixedElements } from './utils/sidebar'
 import type { StudioHost, StudioUser, DatabaseItem, MediaItem, Repository } from 'nuxt-studio/app'
 import type { RouteLocationNormalized, Router } from 'vue-router'
@@ -18,14 +18,6 @@ import { getCollectionSourceById } from './utils/source'
 import { kebabCase } from 'scule'
 
 const serviceWorkerVersion = 'v0.0.5'
-
-function toComarkBody(document: DatabaseItem): DatabaseItem {
-  if (document.extension !== 'md' || !document.body) return document
-  if (isComarkTree(document.body)) return document
-  const comarkTree = comarkTreeFromLegacyDocument(document)
-  if (!comarkTree) return document
-  return { ...document, body: comarkTree as unknown }
-}
 
 function getLocalColorMode(): 'light' | 'dark' {
   return document.documentElement.classList.contains('dark') ? 'dark' : 'light'
@@ -214,7 +206,7 @@ export function useStudioHost(user: StudioUser, repository: Repository): StudioH
             return undefined
           }
 
-          return toComarkBody(sanitizeDocumentTree({ ...item, fsPath }, collectionInfo))
+          return ensureComarkBody(sanitizeDocumentTree({ ...item, fsPath }, collectionInfo))
         },
         list: async (): Promise<DatabaseItem[]> => {
           const collections = Object.values(useContentCollections()).filter(collection => collection.name !== 'info')
@@ -225,7 +217,7 @@ export function useStudioHost(user: StudioUser, repository: Repository): StudioH
               const source = getCollectionSourceById(document.id, collection.source)
               const fsPath = generateFsPathFromId(document.id, source!)
 
-              return toComarkBody(sanitizeDocumentTree({ ...document, fsPath }, collection))
+              return ensureComarkBody(sanitizeDocumentTree({ ...document, fsPath }, collection))
             })
           }))
 
@@ -249,7 +241,7 @@ export function useStudioHost(user: StudioUser, repository: Repository): StudioH
 
           await host.document.db.upsert(fsPath, normalizedDocument)
 
-          return toComarkBody(sanitizeDocumentTree({ ...normalizedDocument, fsPath }, collectionInfo))
+          return ensureComarkBody(sanitizeDocumentTree({ ...normalizedDocument, fsPath }, collectionInfo))
         },
         upsert: async (fsPath: string, document: CollectionItemBase) => {
           const collectionInfo = getCollectionByFilePath(fsPath, useContentCollections())
@@ -286,6 +278,7 @@ export function useStudioHost(user: StudioUser, repository: Repository): StudioH
         isMatchingContent: async (content: string, document: DatabaseItem) => isDocumentMatchingContent(content, document),
         pickReservedKeys: (document: DatabaseItem) => pickReservedKeysFromDocument(document),
         cleanDataKeys: (document: DatabaseItem) => cleanDataKeys(document),
+        ensureComarkBody: (document: DatabaseItem) => ensureComarkBody(document),
         detectActives: () => {
           // TODO: introduce a new convention to detect data contents [data-content-id!]
           const wrappers = document.querySelectorAll('[data-content-id]')

--- a/src/module/src/runtime/utils/document/compare.ts
+++ b/src/module/src/runtime/utils/document/compare.ts
@@ -5,6 +5,14 @@ import { doObjectsMatch } from '../object'
 import { renderMarkdown } from 'comark/render'
 import { documentFromContent } from './generate'
 import { cleanDataKeys } from './schema'
+import { comarkTreeFromLegacyDocument } from './legacy'
+
+const EMPTY_TREE: ComarkTree = { nodes: [], frontmatter: {}, meta: {} }
+
+// Legacy bodies (MarkdownRoot/minimark, no `.nodes`) make renderMarkdown throw unless upgraded.
+function comarkBody(document: Record<string, unknown>): ComarkTree {
+  return comarkTreeFromLegacyDocument(document as DatabaseItem) ?? EMPTY_TREE
+}
 
 /**
  * Sort and normalize every element's attributes alphabetically.
@@ -33,7 +41,7 @@ export async function isDocumentMatchingContent(content: string, document: Datab
   if (generatedDocument.extension === ContentFileExtension.Markdown) {
     // Compare body nodes only (not frontmatter — that's compared separately via doObjectsMatch below).
     const generatedNormalized = normalizeAttrsDeep({ ...(generatedDocument.body as ComarkTree), frontmatter: {} })
-    const documentNormalized = normalizeAttrsDeep({ ...(document.body as ComarkTree), frontmatter: {} })
+    const documentNormalized = normalizeAttrsDeep({ ...comarkBody(document), frontmatter: {} })
     const generatedBodyStringified = (await renderMarkdown(generatedNormalized)).replace(/\n/g, '')
     const documentBodyStringified = (await renderMarkdown(documentNormalized)).replace(/\n/g, '')
     if (generatedBodyStringified !== documentBodyStringified) {
@@ -56,7 +64,7 @@ export async function areDocumentsEqual(document1: Record<string, unknown>, docu
 
   // Compare body first
   if (document1.extension === ContentFileExtension.Markdown) {
-    if (await renderMarkdown(body1 as ComarkTree) !== await renderMarkdown(body2 as ComarkTree)) {
+    if (await renderMarkdown(comarkBody(document1)) !== await renderMarkdown(comarkBody(document2))) {
       return false
     }
   }

--- a/src/module/src/runtime/utils/document/generate.ts
+++ b/src/module/src/runtime/utils/document/generate.ts
@@ -12,7 +12,7 @@ import yaml from 'js-yaml'
 import { useHostMeta } from '../../composables/useMeta'
 import { addPageTypeFields, generateStemFromId, getFileExtension } from './utils'
 import { cleanDataKeys } from './schema'
-import { unbindComarkTree } from './legacy'
+import { comarkTreeFromLegacyDocument, unbindComarkTree } from './legacy'
 
 const logger = consola.withTag('Nuxt Studio')
 
@@ -157,7 +157,9 @@ export async function contentFromJSONDocument(document: DatabaseItem): Promise<s
 }
 
 export async function contentFromMarkdownDocument(document: DatabaseItem): Promise<string | null> {
-  const body = unbindComarkTree(document.body as unknown as ComarkTree)
+  const tree = comarkTreeFromLegacyDocument(document)
+  if (!tree) return '\n'
+  const body = unbindComarkTree(tree)
   const markdown = await renderMarkdown(body, {
     blockAttributesStyle: 'frontmatter',
     components: {

--- a/src/module/src/runtime/utils/document/index.ts
+++ b/src/module/src/runtime/utils/document/index.ts
@@ -27,6 +27,7 @@ export {
 
 // Legacy compatibility — delete this section when @nuxt/content natively returns ComarkTree bodies
 export {
+  ensureComarkBody,
   comarkTreeFromLegacyDocument,
   markdownRootFromComarkTree,
 } from './legacy'

--- a/src/module/src/runtime/utils/document/legacy.ts
+++ b/src/module/src/runtime/utils/document/legacy.ts
@@ -7,11 +7,12 @@
  * When @nuxt/content releases native ComarkTree body support:
  *   1. Delete this file
  *   2. Fix TypeScript errors at call sites:
- *      - host.ts      → remove toComarkBody helper + all db.get/list/create calls to it,
+ *      - host.ts      → remove the ensureComarkBody import + all db.get/list/create calls to it,
  *                       remove markdownRootFromComarkTree usage in db.upsert
- *      - compare.ts   → update toMarkdownRoot helper to compare ComarkTrees directly
- *      - index.ts     → remove re-exports of comarkTreeFromLegacyDocument and markdownRootFromComarkTree
+ *      - compare.ts   → drop the comarkBody helper and compare ComarkTrees directly
  *      - generate.ts  → remove unbindComarkTree usage in contentFromMarkdownDocument
+ *      - index.ts     → remove re-exports of ensureComarkBody, comarkTreeFromLegacyDocument and markdownRootFromComarkTree
+ *      - useDraftBase.ts → remove upgradeLegacyBodies + its host.document.utils.ensureComarkBody call
  */
 
 import type { MarkdownRoot } from '@nuxt/content'
@@ -484,6 +485,15 @@ export function comarkTreeFromLegacyDocument(document: DatabaseItem): ComarkTree
     ? decompressTree(document.body as never)
     : (document.body as MDCRoot)
   return mdcToComark(body, cleanDataKeys(document) as Record<string, unknown>)
+}
+
+// Legacy body (MarkdownRoot/minimark) → ComarkTree, applied at read boundaries so consumers only see comark.
+export function ensureComarkBody(document: DatabaseItem): DatabaseItem {
+  if (document.extension !== 'md' || !document.body) return document
+  if (isComarkTree(document.body)) return document
+  const comarkTree = comarkTreeFromLegacyDocument(document)
+  if (!comarkTree) return document
+  return { ...document, body: comarkTree as unknown }
 }
 
 /**

--- a/src/module/test/integration/document.test.ts
+++ b/src/module/test/integration/document.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest'
-import { contentFromMarkdownDocument, documentFromMarkdownContent } from '../../src/runtime/utils/document'
+import { areDocumentsEqual, contentFromMarkdownDocument, documentFromMarkdownContent, ensureComarkBody, isDocumentMatchingContent } from '../../src/runtime/utils/document'
+import { markdownRootFromComarkTree } from '../../src/runtime/utils/document/legacy'
+import type { ComarkTree } from 'comark'
+import type { DatabaseItem } from 'nuxt-studio/app'
+
+// Downgrades a comark document to the minimark body older Studio builds persisted.
+async function legacyBodyOf(id: string, content: string): Promise<{ comark: DatabaseItem, legacy: DatabaseItem }> {
+  const comark = await documentFromMarkdownContent(id, content) as DatabaseItem
+  const legacy = { ...comark, body: markdownRootFromComarkTree(comark.body as unknown as ComarkTree) as unknown } as DatabaseItem
+  return { comark, legacy }
+}
 
 describe('Document - Markdown roundtrip Integration Tests', () => {
   describe('code block with component inside named slot', () => {
@@ -36,6 +46,105 @@ hello
       const markdown = await contentFromMarkdownDocument(document)
 
       expect(markdown!.trim()).toBe(content.trim())
+    })
+  })
+
+  describe('non-comark stored bodies (drafts persisted by older Studio builds)', () => {
+    const content = `# Hello
+
+A paragraph with **bold** text.
+`
+
+    it('renders a legacy minimark body (no nodes) without throwing', async () => {
+      const { legacy } = await legacyBodyOf('content:legacy.md', content)
+
+      const markdown = await contentFromMarkdownDocument(legacy)
+
+      expect(markdown!.trim()).toBe(content.trim())
+    })
+
+    it('renders a raw MarkdownRoot body ({type:"root", children}, no nodes) without throwing', async () => {
+      const markdownRootBody = {
+        type: 'root',
+        children: [
+          { type: 'element', tag: 'h1', props: {}, children: [{ type: 'text', value: 'Hello' }] },
+          { type: 'element', tag: 'p', props: {}, children: [
+            { type: 'text', value: 'A paragraph with ' },
+            { type: 'element', tag: 'strong', props: {}, children: [{ type: 'text', value: 'bold' }] },
+            { type: 'text', value: ' text.' },
+          ] },
+        ],
+      }
+      const document = { id: 'content:legacy.md', extension: 'md', stem: 'legacy', meta: {}, body: markdownRootBody } as unknown as DatabaseItem
+
+      const markdown = await contentFromMarkdownDocument(document)
+
+      expect(markdown!.trim()).toBe(content.trim())
+    })
+
+    it('renders a legacy body containing an MDC component without throwing', async () => {
+      const componentContent = '::alert{type="info"}\nhello\n::\n'
+      const { legacy } = await legacyBodyOf('content:legacy.md', componentContent)
+
+      const markdown = await contentFromMarkdownDocument(legacy)
+
+      expect(markdown!.trim()).toBe(componentContent.trim())
+    })
+
+    it('returns an empty document for a markdown body that is missing entirely', async () => {
+      const document = { id: 'content:empty.md', extension: 'md', stem: 'empty', meta: {} } as DatabaseItem
+
+      const markdown = await contentFromMarkdownDocument(document)
+
+      expect(markdown).toBe('\n')
+    })
+
+    it('treats a legacy body and its comark equivalent as equal', async () => {
+      const { comark, legacy } = await legacyBodyOf('content:page.md', content)
+
+      expect(await areDocumentsEqual(legacy, comark)).toBe(true)
+    })
+
+    it('matches a legacy body against its own raw markdown content', async () => {
+      const { legacy } = await legacyBodyOf('content:legacy.md', content)
+
+      expect(await isDocumentMatchingContent(content, legacy)).toBe(true)
+    })
+  })
+
+  describe('ensureComarkBody', () => {
+    it('upgrades a legacy body to a ComarkTree (adds .nodes)', async () => {
+      const { legacy } = await legacyBodyOf('content:legacy.md', '# Hello\n')
+
+      const upgraded = ensureComarkBody(legacy)
+
+      expect(Array.isArray((upgraded.body as ComarkTree).nodes)).toBe(true)
+    })
+
+    it('returns an already-comark document untouched (no re-parse)', async () => {
+      const comark = await documentFromMarkdownContent('content:comark.md', '# Hello\n') as DatabaseItem
+
+      expect(ensureComarkBody(comark)).toBe(comark)
+    })
+
+    it('returns a non-markdown document untouched', () => {
+      const yamlDoc = { id: 'content:data.yml', extension: 'yml', body: { some: 'value' } } as unknown as DatabaseItem
+
+      expect(ensureComarkBody(yamlDoc)).toBe(yamlDoc)
+    })
+
+    it('returns a bodyless document untouched', () => {
+      const document = { id: 'content:empty.md', extension: 'md' } as DatabaseItem
+
+      expect(ensureComarkBody(document)).toBe(document)
+    })
+
+    it('is idempotent', async () => {
+      const { legacy } = await legacyBodyOf('content:legacy.md', '# Hello\n')
+
+      const once = ensureComarkBody(legacy)
+
+      expect(ensureComarkBody(once)).toBe(once)
     })
   })
 })


### PR DESCRIPTION
Older Studio builds persisted legacy (MarkdownRoot/minimark) bodies in IndexedDB. comark's `renderMarkdown` expects a `ComarkTree` and threw on publish/render.

Fix: upgrade legacy bodies to `ComarkTree` at the read boundaries — host DB reads (`db.get/list/create`) and draft load (`useDraftBase`) — via `ensureComarkBody` in the legacy compat layer, so consumers only ever see comark.

Temporary compat shim; `legacy.ts` documents every call site to delete once `@nuxt/content` returns `ComarkTree` natively.