### PR TITLE
fix(document): serialize hard breaks as markdown

### DIFF
--- a/src/module/src/runtime/utils/document/generate.ts
+++ b/src/module/src/runtime/utils/document/generate.ts
@@ -13,6 +13,7 @@ import { useHostMeta } from '../../composables/useMeta'
 import { addPageTypeFields, generateStemFromId, getFileExtension } from './utils'
 import { cleanDataKeys } from './schema'
 import { unbindComarkTree } from './legacy'
+import { normalizeMarkdownHardBreaks } from './hard-breaks'
 
 const logger = consola.withTag('Nuxt Studio')
 
@@ -157,11 +158,11 @@ export async function contentFromJSONDocument(document: DatabaseItem): Promise<s
 }
 
 export async function contentFromMarkdownDocument(document: DatabaseItem): Promise<string | null> {
-  const body = unbindComarkTree(document.body as unknown as ComarkTree)
+  const body = normalizeMarkdownHardBreaks(unbindComarkTree(document.body as unknown as ComarkTree))
   const markdown = await renderMarkdown(body, {
     blockAttributesStyle: 'frontmatter',
     components: {
-      br: () => ':br',
+      br: () => '  \n',
     },
   })
   return markdown.replace(/&#x2A;/g, '*') + '\n'

--- a/src/module/src/runtime/utils/document/hard-breaks.ts
+++ b/src/module/src/runtime/utils/document/hard-breaks.ts
@@ -1,0 +1,59 @@
+import type { ComarkElement, ComarkNode, ComarkTree } from 'comark'
+
+const TRAILING_MARKDOWN_HARD_BREAK = / {2}\n$/
+const LEADING_LINE_BREAK = /^\n/
+
+/**
+ * Keep Markdown hard breaks idempotent when a document is opened and saved again.
+ *
+ * Parsed Markdown hard breaks can be represented as both text (`"  \n"`) and a
+ * structural `br` node in the same paragraph. Rendering both forms creates an
+ * extra blank line on every subsequent save, so the save path keeps the `br`
+ * node and removes only the adjacent duplicate parser text.
+ */
+export function normalizeMarkdownHardBreaks(tree: ComarkTree): ComarkTree {
+  return {
+    ...tree,
+    nodes: tree.nodes.map(normalizeHardBreakNode),
+  }
+}
+
+function normalizeHardBreakNode(node: ComarkNode): ComarkNode {
+  if (typeof node === 'string' || !Array.isArray(node)) {
+    return node
+  }
+
+  const [tag, attrs, ...children] = node
+  const normalizedChildren = normalizeHardBreakChildren(children.map(normalizeHardBreakNode))
+
+  return [tag, attrs, ...normalizedChildren] as ComarkNode
+}
+
+function normalizeHardBreakChildren(children: ComarkNode[]): ComarkNode[] {
+  const normalizedChildren = [...children]
+
+  normalizedChildren.forEach((child, index) => {
+    if (isHardBreakNode(child)) {
+      removeDuplicateHardBreakTextAround(normalizedChildren, index)
+    }
+  })
+
+  return normalizedChildren
+}
+
+function removeDuplicateHardBreakTextAround(children: ComarkNode[], hardBreakIndex: number): void {
+  const previous = children[hardBreakIndex - 1]
+  const next = children[hardBreakIndex + 1]
+
+  if (typeof previous === 'string') {
+    children[hardBreakIndex - 1] = previous.replace(TRAILING_MARKDOWN_HARD_BREAK, '')
+  }
+
+  if (typeof next === 'string') {
+    children[hardBreakIndex + 1] = next.replace(LEADING_LINE_BREAK, '')
+  }
+}
+
+function isHardBreakNode(node: ComarkNode | undefined): node is ComarkElement {
+  return Array.isArray(node) && node[0] === 'br'
+}

--- a/src/module/test/integration/document.test.ts
+++ b/src/module/test/integration/document.test.ts
@@ -1,7 +1,29 @@
 import { describe, it, expect } from 'vitest'
 import { contentFromMarkdownDocument, documentFromMarkdownContent } from '../../src/runtime/utils/document'
+import { ContentFileExtension } from '../../src/types/content'
+import type { DatabaseItem } from 'nuxt-studio/app'
 
 describe('Document - Markdown roundtrip Integration Tests', () => {
+  describe('hard breaks', () => {
+    it('serializes duplicated hard-break parser output as one markdown hard break', async () => {
+      const document: DatabaseItem = {
+        id: 'content:test.md',
+        extension: ContentFileExtension.Markdown,
+        stem: 'test',
+        meta: {},
+        body: {
+          frontmatter: {},
+          meta: {},
+          nodes: [
+            ['p', {}, 'Line one  \n', ['br', {}], '\nLine two'],
+          ],
+        },
+      }
+
+      await expect(contentFromMarkdownDocument(document)).resolves.toBe('Line one  \nLine two\n')
+    })
+  })
+
   describe('code block with component inside named slot', () => {
     it('preserves a code block inside an MDC component #code slot', async () => {
       const content = `::component


### PR DESCRIPTION
## Summary

Serialize Comark `br` nodes as Markdown hard breaks (`two spaces + newline`) instead of `:br`.

Also normalize mixed parser output before Markdown rendering so documents that contain both hard-break text and a structural `br` node save idempotently instead of gaining blank lines after reopen/restart/save cycles.

Refs: https://github.com/nuxt-content/nuxt-studio/issues/265

## Test

- `pnpm vitest run src/module/test/integration/document.test.ts`