### PR TITLE
fix(document): serialize hard breaks as markdown

### DIFF
--- a/src/app/test/integration/tiptap.test.ts
+++ b/src/app/test/integration/tiptap.test.ts
@@ -1195,7 +1195,7 @@ My icon
     expect(outputContent).toBe(`${inputContent}\n`)
   })
 
-  test('inline element :br preserves through roundtrip', async () => {
+  test('hard break serializes as a markdown hard break through roundtrip', async () => {
     const inputContent = 'Hello :br world'
 
     const expectedComarkNodes = [
@@ -1240,7 +1240,7 @@ My icon
 
     const outputContent = await contentFromDocument(generatedDocument)
 
-    expect(outputContent).toBe(`${inputContent}\n`)
+    expect(outputContent).toBe('Hello   \n world\n')
   })
 
   test('inline element with slot content', async () => {

--- a/src/module/src/runtime/utils/document/generate.ts
+++ b/src/module/src/runtime/utils/document/generate.ts
@@ -162,9 +162,6 @@ export async function contentFromMarkdownDocument(document: DatabaseItem): Promi
   const body = unbindComarkTree(tree)
   const markdown = await renderMarkdown(body, {
     blockAttributesStyle: 'frontmatter',
-    components: {
-      br: () => ':br',
-    },
   })
   return markdown.replace(/&#x2A;/g, '*') + '\n'
 }

--- a/src/module/test/integration/document.test.ts
+++ b/src/module/test/integration/document.test.ts
@@ -12,6 +12,22 @@ async function legacyBodyOf(id: string, content: string): Promise<{ comark: Data
 }
 
 describe('Document - Markdown roundtrip Integration Tests', () => {
+  describe('hard breaks', () => {
+    it('serializes a hard break as a markdown hard break, not :br', async () => {
+      const document = await documentFromMarkdownContent('content:test.md', 'Line one  \nLine two')
+
+      await expect(contentFromMarkdownDocument(document)).resolves.toBe('Line one  \nLine two\n')
+    })
+
+    it('round-trips a hard break idempotently (no blank-line accumulation)', async () => {
+      const first = await documentFromMarkdownContent('content:test.md', 'Line one  \nLine two')
+      const rendered = await contentFromMarkdownDocument(first)
+      const second = await documentFromMarkdownContent('content:test.md', rendered!)
+
+      await expect(contentFromMarkdownDocument(second)).resolves.toBe('Line one  \nLine two\n')
+    })
+  })
+
   describe('code block with component inside named slot', () => {
     it('preserves a code block inside an MDC component #code slot', async () => {
       const content = `::component


### PR DESCRIPTION
## Summary

The visual editor's hard break (Shift+Enter → TipTap `hardBreak` → Comark `['br', {}]`) was serialized to Markdown as the literal `:br`. That output is broken:

- the deployed Nuxt Content site renders it as `--- Unknown node: hard break ---`
- `:br` collides with the emoji plugin's `:br:` shortcode (Brazilian flag)

## Root cause

The `br: () => ':br'` override in `contentFromMarkdownDocument` was added during the comark migration (#355) purely to reproduce the old `@nuxtjs/mdc` `stringifyMarkdown` output. Comark now renders `['br', {}]` **natively** as a Markdown hard break (`  \n`), so the override no longer matches comark and actively corrupts output — it glues the token to neighbouring text (`Line one:brLine two`).

## Fix

Delete the override and defer to comark's native rendering. This also makes `contentFromMarkdownDocument` consistent with every other `renderMarkdown` call site in the repo (`compare.ts`, `completion.ts`), which already render `br` natively - removing a latent divergence that could feed the formatting-banner / conflict-detection comparisons.

Resolves #265