### PR TITLE
feat: defineStudioMeta prop and slot annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "./app/service-worker": {
       "types": "./dist/app/service-worker.d.ts",
       "default": "./dist/app/service-worker.js"
+    },
+    "./component-meta": {
+      "types": "./dist/app/component-meta.d.ts",
+      "default": "./dist/app/component-meta.js"
     }
   },
   "files": [
@@ -61,7 +65,7 @@
     "destr": "^2.0.5",
     "js-yaml": "^4.2.0",
     "minimatch": "^10.2.5",
-    "nuxt-component-meta": "^0.17.2",
+    "nuxt-component-meta": "https://pkg.pr.new/nuxt-component-meta@05f350d",
     "shiki": "^4.2.0",
     "unstorage": "1.17.5",
     "zod": "^4.4.3",

--- a/playground/docus/app/components/content/AuthorCard.vue
+++ b/playground/docus/app/components/content/AuthorCard.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { defineStudioMeta, ui, media, icon, select, collectionItem, hidden } from 'nuxt-studio/component-meta'
+
+/**
+ * Demo of the `defineStudioMeta` compiler macro. Only works in globally
+ * registered components (`components/content/`), since nuxt-component-meta
+ * is installed with `globalsOnly: true`.
+ */
+defineStudioMeta({
+  props: {
+    cover: ui({ label: 'Cover image', description: 'Displayed at the top of the card', type: media() }),
+    badge: ui({ label: 'Badge icon', type: icon({ libraries: ['lucide'] }) }),
+    author: ui({ label: 'Author', description: 'Main author of the card', type: collectionItem({ collection: 'authors', field: 'stem' }) }),
+    friends: collectionItem({ collection: 'authors', field: 'stem', multiple: true }),
+    variant: select({ options: ['default', 'outlined', 'minimal'] }),
+    internal: hidden(),
+    note: { label: 'Note', input: 'textarea', description: 'Shown in small print under the card' },
+  },
+  slots: {
+    title: { label: 'Author headline' },
+    description: { label: 'Short description', description: 'Displayed under the headline' },
+  },
+})
+
+withDefaults(defineProps<{
+  cover?: string
+  badge?: string
+  author?: string
+  friends?: string[]
+  variant?: string
+  internal?: string
+  note?: string
+}>(), {
+  variant: 'default',
+})
+</script>
+
+<template>
+  <div
+    class="author-card"
+    :class="`author-card--${variant}`"
+  >
+    <img
+      v-if="cover"
+      :src="cover"
+      alt=""
+      class="author-card__cover"
+    >
+    <p v-if="badge">
+      <UIcon :name="badge" /> {{ badge }}
+    </p>
+    <h3><slot name="title" /></h3>
+    <p><slot name="description" /></p>
+    <p v-if="author">
+      Author: {{ author }}
+    </p>
+    <p v-if="friends?.length">
+      Friends: {{ friends.join(', ') }}
+    </p>
+    <small v-if="note">{{ note }}</small>
+  </div>
+</template>
+
+<style scoped>
+.author-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 1rem;
+  margin: 1rem 0;
+}
+
+.author-card--outlined {
+  border-width: 2px;
+}
+
+.author-card--minimal {
+  border: none;
+  padding: 0.5rem 0;
+}
+
+.author-card__cover {
+  max-width: 100%;
+  border-radius: 6px;
+}
+</style>

--- a/playground/docus/content/3.pages/author-card.md
+++ b/playground/docus/content/3.pages/author-card.md
@@ -1,0 +1,26 @@
+---
+title: Author card demo
+description: Demo page for the defineStudioMeta prop and slot annotations.
+---
+
+# Author card demo
+
+This page demonstrates the `defineStudioMeta` annotations: open the component props in Studio to see the custom labels, media/icon pickers, select options, hidden props and the collection reference pickers.
+
+::author-card
+---
+cover: /landscapes/mountains.webp
+badge: i-lucide-rocket
+author: authors/atinux
+variant: outlined
+note: Rendered from the author-card demo page.
+friends:
+  - authors/farnabaz
+  - authors/larbish
+---
+#title
+Sébastien Chopin
+
+#description
+Creator of Nuxt and open source enthusiast.
+::

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@nuxt/content': ^3.14.0
   comark: https://pkg.pr.new/comark@aba6281
+  nuxt-component-meta: https://pkg.pr.new/nuxt-component-meta@05f350d
   '@unhead/vue': 2.1.12
   minimark: ^0.2.0
   unimport: 5.6.0
@@ -51,8 +52,8 @@ importers:
         specifier: ^10.2.5
         version: 10.2.5
       nuxt-component-meta:
-        specifier: ^0.17.2
-        version: 0.17.2(magicast@0.5.3)
+        specifier: https://pkg.pr.new/nuxt-component-meta@05f350d
+        version: https://pkg.pr.new/nuxt-component-meta@05f350d(magicast@0.5.3)
       shiki:
         specifier: ^4.2.0
         version: 4.2.0
@@ -2007,6 +2008,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@oxc-parser/binding-android-arm-eabi@0.129.0':
+    resolution: {integrity: sha512-sG37CfXLlYXdDrggAFO/mKcO4w36piwf862xAZXIuf3nzKhWK1FvW4dqie+06++z+mDto2QeOQSvhyzBeK5jsQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@oxc-parser/binding-android-arm-eabi@0.133.0':
     resolution: {integrity: sha512-l/44caGse+VpnY9gx0yvvc5QnnG3yG1FO3KZgYvNL1GZrfK86zIwAOgGEVlxDyRymzrU/KHiblPFpevKOmJmUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2021,6 +2028,12 @@ packages:
 
   '@oxc-parser/binding-android-arm64@0.128.0':
     resolution: {integrity: sha512-BbeDmuohoJ7Rz/it5wnkj69i/OsCPS3Z51nLEzwO/Y6YshtC4JU+15oNwhY8v4LRKRYclRc7ggOikwrsJ/eOEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.129.0':
+    resolution: {integrity: sha512-DVyLFN2+S0VOhT6lm5++tFqlu3x2Njiby6y5DhTzjV5uRsZWpifsBn6+yjtwAxl105peEjs5BHE3ToBJuQjLTg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -2043,6 +2056,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@oxc-parser/binding-darwin-arm64@0.129.0':
+    resolution: {integrity: sha512-QeqThtB8qax4IL+NFBWgshudyKkj5c076L8vyd8PCEx7U1wHyIbH49MEQ5J5iURFhUW5jiFmdnLKEwyOo0GAJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxc-parser/binding-darwin-arm64@0.133.0':
     resolution: {integrity: sha512-q8dWmnU/8ea2tga9w2f1PinQ5rcMPDUGkF64T189b65YMjUomET4oy5oRldOr4AwOQkneOG/Zttnz1Dvrc62wg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2057,6 +2076,12 @@ packages:
 
   '@oxc-parser/binding-darwin-x64@0.128.0':
     resolution: {integrity: sha512-rWI2Hb1Nt3U/vKsjyNvZzDC8i/l144U20DKjhzaTmwIhIiSRGeroPWWiImwypmKLqrw8GuIixbWJkpGWLbkzrQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.129.0':
+    resolution: {integrity: sha512-zn5+7nv4DlK4uFgblmhKm6xRV0QUHXOHyIDkjmhxJ53xSA9ahkb3pHNiHesNPXn/nK/VWU+C+Z6JYHdatZBh7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -2079,6 +2104,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@oxc-parser/binding-freebsd-x64@0.129.0':
+    resolution: {integrity: sha512-SPTcDBiHWlgRpWFC1jnoi0sBWqCw4DFR+4b8+dV+NAhUu2ONERWyIVIOCfcE9a8BlvZsDCuXf3l/x7wQUs1Rsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxc-parser/binding-freebsd-x64@0.133.0':
     resolution: {integrity: sha512-OpaSv4pW3KgFrMYQxTaS0aOE4T1DQF3qZE/4B6uqqv1KgPWWd4UQhJALi8PJPX1RRV5K7ThKXRfF7qGg2+3l1A==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2093,6 +2124,12 @@ packages:
 
   '@oxc-parser/binding-linux-arm-gnueabihf@0.128.0':
     resolution: {integrity: sha512-093zNw0zZ/e/obML+rhlSdmnzR0mVZluPcAkxunEc5E3F0yBVsFn24Y1ILfsEte11Ud041qn/gp2OJ1jxNqUng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.129.0':
+    resolution: {integrity: sha512-Rgc9+WNKLbc+chyDTXyyJ7gbgLo+ve27CrRnmIwGgucGflrBZbutge5jdPPegcgf46RrR4dkBbMCp0/x16mdig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -2115,6 +2152,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.129.0':
+    resolution: {integrity: sha512-YtSsJ51VysXqlO8Cs2mWTyXvxBRemTHj4WDQjXwKl0SAxh+CVrEdXrdH+RnjxLj3JCUMFeYuHs5c+/DImfbKkg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxc-parser/binding-linux-arm-musleabihf@0.133.0':
     resolution: {integrity: sha512-yuZO533Ftonxn/iyoqQzURzLQHMspvsIyfiCSNi1t/ER4eIQaR0SsmUOUm5b/lmSig7IWIUa5/BrbEkAPwcilQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2129,6 +2172,13 @@ packages:
 
   '@oxc-parser/binding-linux-arm64-gnu@0.128.0':
     resolution: {integrity: sha512-Xvm48jJah8TlIrURIjNOP/gNiGe6aKvCB+r06VliflFo8Kq7VOLE8PxtgShJzZIqubrgdMdYfvuPPozn7F6MbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.129.0':
+    resolution: {integrity: sha512-9oK8iQr9KtgI5JhaJ+5IwiQsXEo6NuasFgovtJGrdK/RxbA0bO4YKRvVY7M+8lozUCVz1U7XrFFODv3emIOPRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2155,6 +2205,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-arm64-musl@0.129.0':
+    resolution: {integrity: sha512-GghE/bf9ZqgqZFxLacgP0ImVD6UiLKQOpvpgUoIsqjopu2ms/+p1L0d0Dv2Sck+8p0FbKS2WE3IjqmIlLbxJgA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-linux-arm64-musl@0.133.0':
     resolution: {integrity: sha512-wJQGamIosQBoJHW9+S5XxrtKRo3eyJxsnS1XCPrqN0LHi8uw1pTqqTfn3t/NVuvbBg7Pumn4ez9Eidgcn0xbEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2171,6 +2228,13 @@ packages:
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.128.0':
     resolution: {integrity: sha512-21LGNIZb1Pcfk5/EGsqabrxv4yqQOWis1407JJrClS7XpFCrbvr74YAB1V+m54cYbwvO6UWwQqS4WecxiyfCRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.129.0':
+    resolution: {integrity: sha512-A2PW0UbERzKGV6fKX1zoe2Tkc1zVcEJSSPW9IUSKbZAPuPe+M5/5hTA+6fQbWmevabe2B3IDky66a1lFGjpBKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -2197,6 +2261,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.129.0':
+    resolution: {integrity: sha512-omwxd9H+jrl1T72RI666k4ho7Eli2iHdELzf+dL0D+uXThNZXYJCbKjm5rK2hrHmDy4O+NWv7+khBrEkorLsgw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-riscv64-gnu@0.133.0':
     resolution: {integrity: sha512-R4vOjWzxhnNWHnVLeiB6jNuIifdy9vcMXZGPc7StXcxBovI+U2zg1QhZ9o8OjV80oGivs1lX5NfPLzk4IPqlRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2213,6 +2284,13 @@ packages:
 
   '@oxc-parser/binding-linux-riscv64-musl@0.128.0':
     resolution: {integrity: sha512-X6Q2oKUrP5GyDd2xniuEBLk6aFQCZ97W2+aVXGgJXdjx5t4/oFuA9ri0wLOUrBIX+qdSuK581snMBio4z910eA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.129.0':
+    resolution: {integrity: sha512-v2hi8id+M8C0uY8uuG2t2a5vr8H9XyHXiHL12yMdMNtgn04nnM/8hlOGuoJuxVc07PhClNiaoSaY2eXehSRa7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -2239,6 +2317,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.129.0':
+    resolution: {integrity: sha512-UXrdDyLh1Obgj5X+IVVXWoo5/FJbFsU8/uLQ/M9lkVUwBUKpRFxNEhzwBNv21qqdKgAh+pr2CCVD8J1JfRPsIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-s390x-gnu@0.133.0':
     resolution: {integrity: sha512-ZwZNo8FZmB/gVfboQl+wXilBigGl+6nQQs+nITOeAP/HcAOjiHl6XZJL9F/KXNEspODQcbjAiyjUbeCJd9a0fA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2255,6 +2340,13 @@ packages:
 
   '@oxc-parser/binding-linux-x64-gnu@0.128.0':
     resolution: {integrity: sha512-OO1nW2Q7sSYYvJZpDHdvyFSdRaVcQqRijZSSmWVMqFxPYy8cEF45zJ9fcdIYuzIT3jYq6YRhEFm/VMWNWhE22Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.129.0':
+    resolution: {integrity: sha512-hsL/3/kdX9FGLqOj8DR3Eki4Y6zO1i3+ZHhiPwX0hDt4n+18abkfUzePCv3h8SShprwCmwdxPnlrebZ5+MZ+cw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2281,6 +2373,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-x64-musl@0.129.0':
+    resolution: {integrity: sha512-kdXvJ4crOeRld3vWl0J0VU4nmnT4pZ3lKGA5tZ1y0UPWsBtElDYd+jsz4lE36tpAbCiWm0M0PG0laUNBSE+Wlw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-linux-x64-musl@0.133.0':
     resolution: {integrity: sha512-ssTlpXD5Mq9uCssDJPzlRWqBt4Y7Zzd9i+XZhWmK/9Y6KUIuAxVYTYiI8lxcGWi0+3/Cz4A8q9UrD4NK9Y2j7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2297,6 +2396,12 @@ packages:
 
   '@oxc-parser/binding-openharmony-arm64@0.128.0':
     resolution: {integrity: sha512-kVbqgW9xLL8bh8oc7aYOJilRKXE5G33+tE0jan+duo/9OriaFRpijcCwT2waWs2oqYROYq0GlE7/p3ywoshVeg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-openharmony-arm64@0.129.0':
+    resolution: {integrity: sha512-DusJfcK7EGwf9TEakB+z6SXCLdHGvDZ8U8882bzWb4oVrORHpbkFl9npS7cN3YC2axcVKoktbxZevS1nxVCKFw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -2318,6 +2423,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
+  '@oxc-parser/binding-wasm32-wasi@0.129.0':
+    resolution: {integrity: sha512-Iie9CcII+ELSinKFnxTR15xhI9qriVivEhbFh3driRNbzms/5ioDAU0fwe8Mf1FEaz3n2FtiUVX0h0nwKLYk0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@oxc-parser/binding-wasm32-wasi@0.133.0':
     resolution: {integrity: sha512-2e16tkKp+wDO2GTAmXfxbBcCmGEaFPIJEIRBBmVKNVXSc8/fJsSIaBGyFTPHM9ST5GNWgJcYIt94rDTks+PLwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2330,6 +2440,12 @@ packages:
 
   '@oxc-parser/binding-win32-arm64-msvc@0.128.0':
     resolution: {integrity: sha512-xgvO35GyHBtjlQ5AEpaYr7Rll1rvY7zqIhT6ty8E3ezBW2J1SFLjIDEvI/tcgDg6oaseDAqVcM+jU1HuCekgZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.129.0':
+    resolution: {integrity: sha512-99kH1udLyrts+wGm+u0VhPbogkb2wxc/6J1XMKOpS6Kx5DjBWGRZZfBjfCGI3xKSInpYbZn4TLWLX1Q1GURYwg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -2352,6 +2468,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.129.0':
+    resolution: {integrity: sha512-tmSBR1A4yH697qV291xKyDe4OAWFchJ+cXf2wuipx/vK3n5d5Ej9MVLRtXlIcZ38n8qAjsF0/AnskaYgxM151A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@oxc-parser/binding-win32-ia32-msvc@0.133.0':
     resolution: {integrity: sha512-Una1bNYv9zCavQrfnDR9wuZVB3itLjCEH4Oz7i6CwAJN/Xq9b+zbbcxmvdkKvvJt4Ngc/MBmIYlbLo3zS4TQ0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2366,6 +2488,12 @@ packages:
 
   '@oxc-parser/binding-win32-x64-msvc@0.128.0':
     resolution: {integrity: sha512-NE9ny+cPUCCObXa0IKLfj0tCdPd7pe/dz9ZpkxpUOymB3miNeMPybdlYYTBSGJUalMWeBM85/4JcCErCNTqOXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.129.0':
+    resolution: {integrity: sha512-Z1PbJvkPeLASIUxa3AnrQ5H+vv1K9zC0IGnQqoKfM0ZvsvCSe0d3u5m7d9iuy+HB7GrcElHuwKb0d0qFdtG0iA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2390,6 +2518,9 @@ packages:
 
   '@oxc-project/types@0.128.0':
     resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
+
+  '@oxc-project/types@0.129.0':
+    resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
@@ -6963,8 +7094,9 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  nuxt-component-meta@0.17.2:
-    resolution: {integrity: sha512-2/mSSqutOX8t+r8cAX1yUYwAPBqicPO5Rfum3XaHVszxKCF4tXEXBiPGfJY9Zn69x/CIeOdw+aM9wmHzQ5Q+lA==}
+  nuxt-component-meta@https://pkg.pr.new/nuxt-component-meta@05f350d:
+    resolution: {integrity: sha512-wa/A50I+q/p9m6V3CmB0/suF/Ef8LUMmZIhSbjOTNfO/x9kEN+6btGp6qcwr1E+q8SAVXbc/ZuYA4on2s1rDFQ==, tarball: https://pkg.pr.new/nuxt-component-meta@05f350d}
+    version: 0.17.2
     hasBin: true
 
   nuxt-define@1.0.0:
@@ -7132,6 +7264,10 @@ packages:
 
   oxc-parser@0.128.0:
     resolution: {integrity: sha512-XkOw3eiIxAgQ19WRew/Bq9wc5Ga/guaWIzDBzq80z1PyuDNGvWBpPby9k6YGwV8A8uMw+Nlq3xqlzuDYmUFYUw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-parser@0.129.0:
+    resolution: {integrity: sha512-S6eFI+VLkpyA+/Lf8z6qURjDV6Mgo74SLNznNopHTlQW3hedv2MB/z31kBRuBCCTqZN9HHdva0ojljEhPnBKFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-parser@0.133.0:
@@ -10535,7 +10671,7 @@ snapshots:
       micromatch: 4.0.8
       minimark: 0.2.0
       minimatch: 10.2.5
-      nuxt-component-meta: 0.17.2(magicast@0.5.3)
+      nuxt-component-meta: https://pkg.pr.new/nuxt-component-meta@05f350d(magicast@0.5.3)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -11711,6 +11847,9 @@ snapshots:
   '@oxc-parser/binding-android-arm-eabi@0.128.0':
     optional: true
 
+  '@oxc-parser/binding-android-arm-eabi@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-android-arm-eabi@0.133.0':
     optional: true
 
@@ -11718,6 +11857,9 @@ snapshots:
     optional: true
 
   '@oxc-parser/binding-android-arm64@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.129.0':
     optional: true
 
   '@oxc-parser/binding-android-arm64@0.133.0':
@@ -11729,6 +11871,9 @@ snapshots:
   '@oxc-parser/binding-darwin-arm64@0.128.0':
     optional: true
 
+  '@oxc-parser/binding-darwin-arm64@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-darwin-arm64@0.133.0':
     optional: true
 
@@ -11736,6 +11881,9 @@ snapshots:
     optional: true
 
   '@oxc-parser/binding-darwin-x64@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.129.0':
     optional: true
 
   '@oxc-parser/binding-darwin-x64@0.133.0':
@@ -11747,6 +11895,9 @@ snapshots:
   '@oxc-parser/binding-freebsd-x64@0.128.0':
     optional: true
 
+  '@oxc-parser/binding-freebsd-x64@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-freebsd-x64@0.133.0':
     optional: true
 
@@ -11754,6 +11905,9 @@ snapshots:
     optional: true
 
   '@oxc-parser/binding-linux-arm-gnueabihf@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.129.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-gnueabihf@0.133.0':
@@ -11765,6 +11919,9 @@ snapshots:
   '@oxc-parser/binding-linux-arm-musleabihf@0.128.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm-musleabihf@0.133.0':
     optional: true
 
@@ -11772,6 +11929,9 @@ snapshots:
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.129.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.133.0':
@@ -11783,6 +11943,9 @@ snapshots:
   '@oxc-parser/binding-linux-arm64-musl@0.128.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm64-musl@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm64-musl@0.133.0':
     optional: true
 
@@ -11790,6 +11953,9 @@ snapshots:
     optional: true
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.129.0':
     optional: true
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.133.0':
@@ -11801,6 +11967,9 @@ snapshots:
   '@oxc-parser/binding-linux-riscv64-gnu@0.128.0':
     optional: true
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-linux-riscv64-gnu@0.133.0':
     optional: true
 
@@ -11808,6 +11977,9 @@ snapshots:
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-musl@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.129.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-musl@0.133.0':
@@ -11819,6 +11991,9 @@ snapshots:
   '@oxc-parser/binding-linux-s390x-gnu@0.128.0':
     optional: true
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-linux-s390x-gnu@0.133.0':
     optional: true
 
@@ -11826,6 +12001,9 @@ snapshots:
     optional: true
 
   '@oxc-parser/binding-linux-x64-gnu@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.129.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-gnu@0.133.0':
@@ -11837,6 +12015,9 @@ snapshots:
   '@oxc-parser/binding-linux-x64-musl@0.128.0':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-musl@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-linux-x64-musl@0.133.0':
     optional: true
 
@@ -11846,6 +12027,9 @@ snapshots:
   '@oxc-parser/binding-openharmony-arm64@0.128.0':
     optional: true
 
+  '@oxc-parser/binding-openharmony-arm64@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-openharmony-arm64@0.133.0':
     optional: true
 
@@ -11853,6 +12037,13 @@ snapshots:
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.128.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.129.0':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
@@ -11876,6 +12067,9 @@ snapshots:
   '@oxc-parser/binding-win32-arm64-msvc@0.128.0':
     optional: true
 
+  '@oxc-parser/binding-win32-arm64-msvc@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-win32-arm64-msvc@0.133.0':
     optional: true
 
@@ -11885,6 +12079,9 @@ snapshots:
   '@oxc-parser/binding-win32-ia32-msvc@0.128.0':
     optional: true
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-win32-ia32-msvc@0.133.0':
     optional: true
 
@@ -11892,6 +12089,9 @@ snapshots:
     optional: true
 
   '@oxc-parser/binding-win32-x64-msvc@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.129.0':
     optional: true
 
   '@oxc-parser/binding-win32-x64-msvc@0.133.0':
@@ -11905,6 +12105,8 @@ snapshots:
   '@oxc-project/types@0.122.0': {}
 
   '@oxc-project/types@0.128.0': {}
+
+  '@oxc-project/types@0.129.0': {}
 
   '@oxc-project/types@0.133.0': {}
 
@@ -16967,12 +17169,15 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt-component-meta@0.17.2(magicast@0.5.3):
+  nuxt-component-meta@https://pkg.pr.new/nuxt-component-meta@05f350d(magicast@0.5.3):
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       citty: 0.1.6
+      jiti: 2.7.0
       mlly: 1.8.2
       ohash: 2.0.11
+      oxc-parser: 0.129.0
+      oxc-walker: 0.7.0(oxc-parser@0.129.0)
       scule: 1.3.0
       typescript: 5.9.3
       ufo: 1.6.4
@@ -17998,6 +18203,31 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.128.0
       '@oxc-parser/binding-win32-x64-msvc': 0.128.0
 
+  oxc-parser@0.129.0:
+    dependencies:
+      '@oxc-project/types': 0.129.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.129.0
+      '@oxc-parser/binding-android-arm64': 0.129.0
+      '@oxc-parser/binding-darwin-arm64': 0.129.0
+      '@oxc-parser/binding-darwin-x64': 0.129.0
+      '@oxc-parser/binding-freebsd-x64': 0.129.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.129.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.129.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.129.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.129.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.129.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.129.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.129.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.129.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.129.0
+      '@oxc-parser/binding-linux-x64-musl': 0.129.0
+      '@oxc-parser/binding-openharmony-arm64': 0.129.0
+      '@oxc-parser/binding-wasm32-wasi': 0.129.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.129.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.129.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.129.0
+
   oxc-parser@0.133.0:
     dependencies:
       '@oxc-project/types': 0.133.0
@@ -18098,6 +18328,11 @@ snapshots:
     dependencies:
       magic-regexp: 0.10.0
       oxc-parser: 0.128.0
+
+  oxc-walker@0.7.0(oxc-parser@0.129.0):
+    dependencies:
+      magic-regexp: 0.10.0
+      oxc-parser: 0.129.0
 
   oxc-walker@1.0.0(oxc-parser@0.133.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
 overrides:
   "@nuxt/content": "^3.14.0"
   "comark": "https://pkg.pr.new/comark@aba6281"
+  "nuxt-component-meta": "https://pkg.pr.new/nuxt-component-meta@05f350d"
   "@unhead/vue": "2.1.12"
   "minimark": "^0.2.0"
   "unimport": "5.6.0"

--- a/src/app/src/component-meta.ts
+++ b/src/app/src/component-meta.ts
@@ -1,0 +1,68 @@
+import type { ResolvedStudioPropMeta, StudioComponentMeta, StudioPropDisplay, StudioPropMeta } from './types/editor'
+
+export type { StudioComponentMeta, StudioPropMeta, StudioPropDisplay, StudioPropInput, StudioSlotMeta, StudioInputType } from './types/editor'
+
+export interface UiOptions extends StudioPropDisplay {
+  type?: StudioPropMeta
+}
+
+/**
+ * Combine display metadata with a type helper:
+ * `ui({ label: 'Image source', type: media() })`
+ */
+export function ui(options: UiOptions): StudioPropMeta {
+  const { type, ...display } = options
+  const meta = { ...type } as ResolvedStudioPropMeta
+  for (const key of ['label', 'description', 'tooltip', 'hidden'] as const) {
+    if (display[key] !== undefined) {
+      meta[key] = display[key] as never
+    }
+  }
+  return meta as StudioPropMeta
+}
+
+export function media(): StudioPropMeta {
+  return { input: 'media' }
+}
+
+export function icon(options?: { libraries?: string[] }): StudioPropMeta {
+  return options?.libraries ? { input: 'icon', iconLibraries: options.libraries } : { input: 'icon' }
+}
+
+export function textarea(): StudioPropMeta {
+  return { input: 'textarea' }
+}
+
+export function date(): StudioPropMeta {
+  return { input: 'date' }
+}
+
+export function datetime(): StudioPropMeta {
+  return { input: 'datetime' }
+}
+
+export function select(options: { options: string[] }): StudioPropMeta {
+  return { options: options.options }
+}
+
+export function collectionItem(options: { collection: string, multiple?: boolean, field?: string }): StudioPropMeta {
+  const meta: StudioPropMeta = { input: 'reference', collection: options.collection }
+  if (options.multiple !== undefined) {
+    meta.multiple = options.multiple
+  }
+  if (options.field !== undefined) {
+    meta.field = options.field
+  }
+  return meta
+}
+
+export function hidden(): StudioPropMeta {
+  return { hidden: true }
+}
+
+/**
+ * Typed variant of the global `defineStudioMeta` compiler macro, for
+ * explicit-import style. The call is extracted at build time by
+ * nuxt-component-meta and stripped from browser bundles.
+ */
+export function defineStudioMeta(_meta: StudioComponentMeta): void {}

--- a/src/app/src/components/form/FormInput.vue
+++ b/src/app/src/components/form/FormInput.vue
@@ -48,6 +48,11 @@ function computeValue(formItem: FormItem): unknown {
       return typeof value === 'boolean' ? value : false
     case 'number':
       return typeof value === 'number' ? value : 0
+    case 'reference':
+      if (formItem.multiple) {
+        return Array.isArray(value) ? value : []
+      }
+      return typeof value === 'string' ? value : ''
     case 'array':
       return Array.isArray(value) ? value : []
     case 'object':

--- a/src/app/src/components/form/input/InputReference.vue
+++ b/src/app/src/components/form/input/InputReference.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import type { FormItem, DatabaseItem } from '../../../types'
+import type { PropType } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useStudio } from '../../../composables/useStudio'
+
+const props = defineProps({
+  formItem: {
+    type: Object as PropType<FormItem>,
+    default: () => ({}),
+  },
+})
+
+const model = defineModel<string | string[]>()
+
+const { host } = useStudio()
+
+const items = ref<Array<{ label: string, value: string }>>([])
+const isLoading = ref(true)
+
+function referenceValue(item: DatabaseItem): string {
+  const field = props.formItem.field ?? 'path'
+  const value = item[field] ?? item.stem
+  return String(value)
+}
+
+onMounted(async () => {
+  try {
+    const documents = await host.document.db.list()
+    items.value = documents
+      .filter(item => item.fsPath && host.collection.getByFsPath(item.fsPath)?.name === props.formItem.collection)
+      .map(item => ({
+        label: (item.title as string) || item.stem,
+        value: referenceValue(item),
+      }))
+  }
+  finally {
+    isLoading.value = false
+  }
+})
+
+const selectModel = computed({
+  get: () => {
+    if (props.formItem.multiple) {
+      return Array.isArray(model.value) ? model.value : []
+    }
+    return typeof model.value === 'string' ? model.value : undefined
+  },
+  set: (value: string | string[] | undefined) => {
+    model.value = value
+  },
+})
+</script>
+
+<template>
+  <USelectMenu
+    v-model="selectModel"
+    :items="items"
+    value-key="value"
+    label-key="label"
+    :multiple="formItem.multiple"
+    :loading="isLoading"
+    :search-input="{ placeholder: $t('studio.form.reference.searchPlaceholder') }"
+    :placeholder="$t('studio.form.reference.placeholder')"
+    size="xs"
+    class="w-full"
+    :ui="{ content: 'z-[1000]' }"
+  >
+    <template #empty>
+      {{ $t('studio.form.reference.emptyCollection', { collection: formItem.collection }) }}
+    </template>
+  </USelectMenu>
+</template>

--- a/src/app/src/components/form/input/InputWrapper.vue
+++ b/src/app/src/components/form/input/InputWrapper.vue
@@ -12,6 +12,7 @@ import InputText from './InputText.vue'
 import InputObject from './InputObject.vue'
 import InputArray from './InputArray.vue'
 import InputTextarea from './InputTextarea.vue'
+import InputReference from './InputReference.vue'
 
 const typeComponentMap: Partial<Record<FormInputsTypes, Component>> = {
   array: InputArray,
@@ -24,6 +25,7 @@ const typeComponentMap: Partial<Record<FormInputsTypes, Component>> = {
   string: InputText,
   object: InputObject,
   textarea: InputTextarea,
+  reference: InputReference,
 }
 
 const props = defineProps({

--- a/src/app/src/components/tiptap/extension/TiptapExtensionSlot.vue
+++ b/src/app/src/components/tiptap/extension/TiptapExtensionSlot.vue
@@ -4,6 +4,7 @@ import { nodeViewProps, NodeViewWrapper, NodeViewContent } from '@tiptap/vue-3'
 import { kebabCase } from 'scule'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { useStudio } from '../../../composables/useStudio'
+import { getSlotDisplay } from '../../../utils/tiptap/slots'
 
 const nodeProps = defineProps(nodeViewProps)
 
@@ -35,7 +36,10 @@ const usedSlots = computed(() =>
     .map(slot => slot.attrs.name as string),
 )
 // All declared slots minus those already used by siblings (including this slot itself)
-const availableSlots = computed(() => slots.value.map(slot => slot.name).filter(name => !usedSlots.value.includes(name)))
+const availableSlots = computed(() => slots.value
+  .filter(slot => !usedSlots.value.includes(slot.name))
+  .map(slot => ({ value: slot.name, ...getSlotDisplay(componentMeta.value, slot.name) })))
+const currentSlotDisplay = computed(() => getSlotDisplay(componentMeta.value, slotName.value))
 const isLastRemainingSlot = computed(() => parent.value?.childCount === 1)
 
 function deleteSlot() {
@@ -72,12 +76,26 @@ function deleteSlot() {
             <span class="text-muted">#</span>
           </template>
 
+          <template #default>
+            {{ currentSlotDisplay.label }}
+          </template>
+
           <template #empty>
             <div class="text-xs text-muted py-2">
               {{ $t('studio.tiptap.slot.noSlotsAvailable') }}
             </div>
           </template>
         </USelectMenu>
+
+        <UTooltip
+          v-if="currentSlotDisplay.description"
+          :text="currentSlotDisplay.description"
+        >
+          <UIcon
+            name="i-lucide-circle-help"
+            class="size-3.5 text-muted shrink-0"
+          />
+        </UTooltip>
 
         <UTooltip :text="$t('studio.tiptap.slot.deleteSlot')">
           <UButton

--- a/src/app/src/locales/en.json
+++ b/src/app/src/locales/en.json
@@ -407,6 +407,12 @@
       },
       "number": {
         "placeholder": "0"
+      },
+      "reference": {
+        "placeholder": "Select an item...",
+        "searchPlaceholder": "Search items...",
+        "noItemsFound": "No items found",
+        "emptyCollection": "No items in the {collection} collection"
       }
     },
     "ai": {

--- a/src/app/src/shared.ts
+++ b/src/app/src/shared.ts
@@ -1,6 +1,6 @@
 export type { MarkdownParsingOptions } from './types/content'
 export type { GitProviderType } from './types/git'
-export type { ComponentMeta, CommandKey, CommandConfig } from './types/editor'
+export type { ComponentMeta, CommandKey, CommandConfig, StudioComponentMeta, StudioPropMeta, StudioPropDisplay, StudioPropInput, StudioSlotMeta, StudioInputType } from './types/editor'
 export type { AIGenerateOptions, AIHintOptions, CursorContext, DiffPart, AITransformCallbacks } from './types/ai'
 
 // Temporary export for remark emoji plugin

--- a/src/app/src/types/editor.ts
+++ b/src/app/src/types/editor.ts
@@ -1,6 +1,54 @@
 import type { ComponentData } from 'nuxt-component-meta'
 import type { JSType } from 'untyped'
 
+export type StudioInputType = 'media' | 'icon' | 'textarea' | 'date' | 'datetime' | 'string' | 'boolean' | 'number' | 'reference'
+
+export interface StudioPropDisplay {
+  label?: string
+  description?: string
+  tooltip?: string
+  hidden?: boolean
+}
+
+export type StudioPropInput
+  /** No input override: keep the heuristic type, optionally constrain to select options */
+  = | { input?: undefined, options?: string[] }
+    | { input: 'media' | 'textarea' | 'date' | 'datetime' | 'boolean' | 'number' }
+  /** Explicit select options, overrides enum extraction */
+    | { input: 'string', options?: string[] }
+  /** Icon picker, optionally restricted to specific icon libraries */
+    | { input: 'icon', iconLibraries?: string[] }
+  /**
+   * Collection item picker. Stores the item's `field` (defaults to 'path',
+   * falls back to 'stem' for data collections) — an array of them with `multiple`.
+   */
+    | { input: 'reference', collection: string, multiple?: boolean, field?: string }
+
+export type StudioPropMeta = StudioPropDisplay & StudioPropInput
+
+/**
+ * Flat view of StudioPropMeta the editor pipeline reads. Annotations arrive
+ * as plain JSON from `/__nuxt_studio/meta`, so no variant is guaranteed.
+ */
+export interface ResolvedStudioPropMeta extends StudioPropDisplay {
+  input?: StudioInputType
+  iconLibraries?: string[]
+  options?: string[]
+  collection?: string
+  multiple?: boolean
+  field?: string
+}
+
+export interface StudioSlotMeta {
+  label?: string
+  description?: string
+}
+
+export interface StudioComponentMeta {
+  props?: Record<string, StudioPropMeta>
+  slots?: Record<string, StudioSlotMeta>
+}
+
 export interface ComponentMeta {
   name: string
   path: string
@@ -9,10 +57,11 @@ export interface ComponentMeta {
     props: ComponentData['meta']['props']
     slots: ComponentData['meta']['slots']
     events: ComponentData['meta']['events']
+    studio?: StudioComponentMeta
   }
 }
 
-export type FormInputsTypes = JSType | 'icon' | 'media' | 'file' | 'date' | 'datetime' | 'textarea'
+export type FormInputsTypes = JSType | 'icon' | 'media' | 'file' | 'date' | 'datetime' | 'textarea' | 'reference'
 
 export type FormTree = Record<string, FormItem>
 export type FormItem = {
@@ -33,6 +82,9 @@ export type FormItem = {
   label?: string
   description?: string
   tooltip?: string
+  collection?: string
+  multiple?: boolean
+  field?: string
 }
 
 export const COMMAND_KEYS = [

--- a/src/app/src/utils/form.ts
+++ b/src/app/src/utils/form.ts
@@ -1,5 +1,5 @@
-import type { Draft07, Draft07DefinitionProperty, Draft07DefinitionPropertyAnyOf, Draft07DefinitionPropertyAllOf, Draft07DefinitionPropertyOneOf, EditorOptions } from '@nuxt/content'
-import type { FormTree, FormItem } from '../types'
+import type { Draft07, Draft07DefinitionProperty, Draft07DefinitionPropertyAnyOf, Draft07DefinitionPropertyAllOf, Draft07DefinitionPropertyOneOf } from '@nuxt/content'
+import type { FormTree, FormItem, ResolvedStudioPropMeta } from '../types'
 import { upperFirst, titleCase } from 'scule'
 import { omit } from './object'
 
@@ -18,7 +18,7 @@ export function formItemInputLabel(formItem: FormItem): string {
 function editorDisplayFromContent(
   content: Draft07DefinitionProperty['$content'],
 ): Partial<Pick<FormItem, 'label' | 'description' | 'tooltip'>> {
-  const editor = content?.editor as EditorOptions | undefined
+  const editor = content?.editor as ResolvedStudioPropMeta | undefined
   if (!editor) {
     return {}
   }
@@ -38,6 +38,29 @@ function editorDisplayFromContent(
   return result
 }
 
+/**
+ * Reference picker options from `$content.editor` (input: 'reference')
+ */
+function referenceFromEditor(editor: ResolvedStudioPropMeta | undefined): Partial<Pick<FormItem, 'collection' | 'multiple' | 'field'>> {
+  if (editor?.input !== 'reference') {
+    return {}
+  }
+
+  const result: Partial<Pick<FormItem, 'collection' | 'multiple' | 'field'>> = {}
+
+  if (editor.collection !== undefined) {
+    result.collection = editor.collection
+  }
+  if (editor.multiple !== undefined) {
+    result.multiple = editor.multiple
+  }
+  if (editor.field !== undefined) {
+    result.field = editor.field
+  }
+
+  return result
+}
+
 export const buildFormTreeFromSchema = (treeKey: string, schema: Draft07): FormTree => {
   if (!schema || !schema.definitions || !schema.definitions[treeKey]) {
     return {}
@@ -48,7 +71,7 @@ export const buildFormTreeFromSchema = (treeKey: string, schema: Draft07): FormT
     const itemKey = paths.pop()!.replace('#', '')
     const level = paths.length
 
-    const editor = def.$content?.editor
+    const editor = def.$content?.editor as ResolvedStudioPropMeta | undefined
     if (editor?.hidden) {
       return null
     }
@@ -125,8 +148,8 @@ export const buildFormTreeFromSchema = (treeKey: string, schema: Draft07): FormT
         return item
       }
 
-      // Array form
-      if (def.type === 'array' && def.items) {
+      // Array form (an explicit editor input takes over, e.g. a multiple reference)
+      if (def.type === 'array' && def.items && !editor?.input) {
         return {
           id,
           title: upperFirst(itemKey),
@@ -145,9 +168,13 @@ export const buildFormTreeFromSchema = (treeKey: string, schema: Draft07): FormT
         title: upperFirst(itemKey),
         type: editorType ?? type,
         ...editorDisplayFromContent(def.$content),
+        ...referenceFromEditor(editor),
       }
 
-      if (def.enum && Array.isArray(def.enum) && def.enum.length > 0) {
+      if (editor?.options && Array.isArray(editor.options) && editor.options.length > 0) {
+        item.options = editor.options
+      }
+      else if (def.enum && Array.isArray(def.enum) && def.enum.length > 0) {
         item.options = def.enum as string[]
       }
       else if (editor?.iconLibraries && Array.isArray(editor.iconLibraries)) {
@@ -166,13 +193,17 @@ export const buildFormTreeFromSchema = (treeKey: string, schema: Draft07): FormT
       title: upperFirst(itemKey),
       type: editorType ?? type as never,
       ...editorDisplayFromContent(def.$content),
+      ...referenceFromEditor(editor),
     }
 
     if (type === 'array' && def.items) {
       item.arrayItemForm = buildFormTreeItem(def.items, `#${itemKey}/items`)!
     }
 
-    if (def.enum && Array.isArray(def.enum) && def.enum.length > 0) {
+    if (editor?.options && Array.isArray(editor.options) && editor.options.length > 0) {
+      item.options = editor.options
+    }
+    else if (def.enum && Array.isArray(def.enum) && def.enum.length > 0) {
       item.options = def.enum as string[]
     }
     // Pass iconLibraries from editor options for icon inputs

--- a/src/app/src/utils/tiptap/props.ts
+++ b/src/app/src/utils/tiptap/props.ts
@@ -1,9 +1,8 @@
 import { flatCase, pascalCase, titleCase, upperFirst } from 'scule'
 import { hasProtocol, isRelative } from 'ufo'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
-import type { JSType } from 'untyped'
 import type { FormItem, FormTree } from '../../types'
-import type { ComponentMeta } from '../../types/editor'
+import type { ComponentMeta, FormInputsTypes, ResolvedStudioPropMeta } from '../../types/editor'
 import type { PropertyMeta, PropertyMetaSchema } from 'vue-component-meta'
 import type { ComarkElementAttributes } from 'comark'
 
@@ -158,6 +157,7 @@ export function normalizeProps(nodeProps: Record<string, unknown>, extraProps: o
 export const buildFormTreeFromProps = (node: ProseMirrorNode, componentMeta: ComponentMeta): FormTree => {
   const isNuxtUIComponent = componentMeta.nuxtUI ?? false
   const props = componentMeta.meta.props
+  const studioProps = componentMeta.meta.studio?.props
   const nodeProps = node?.attrs?.props || {}
   const formTree: FormTree = {}
   const componentName = pascalCase(node?.attrs?.tag || componentMeta.name)
@@ -172,7 +172,7 @@ export const buildFormTreeFromProps = (node: ProseMirrorNode, componentMeta: Com
         continue
       }
 
-      const propItem = buildPropItem(componentId, prop, nodeProps)
+      const propItem = buildPropItem(componentId, prop, nodeProps, 0, undefined, studioProps?.[prop.name])
 
       if (propItem) {
         formTree[propItem.key!] = propItem
@@ -230,6 +230,15 @@ export const buildFormTreeFromProps = (node: ProseMirrorNode, componentMeta: Com
       formTree[key].hidden = true
     }
 
+    // Studio annotations override all hide heuristics, in both directions
+    const studioHidden = studioProps?.[key.replace(':', '')]?.hidden
+    if (studioHidden === true) {
+      formTree[key].hidden = true
+    }
+    else if (studioHidden === false) {
+      delete formTree[key].hidden
+    }
+
     if (['object', 'array'].includes(formTree[key].type)) {
       const children = formTree[key].type === 'array' ? formTree[key].arrayItemForm?.children : formTree[key].children
       if (children) {
@@ -245,17 +254,22 @@ export const buildFormTreeFromProps = (node: ProseMirrorNode, componentMeta: Com
   return formTree
 }
 
-const buildPropItem = (componentId: string, prop: PropertyMeta, nodeProps: Record<string, unknown>, level = 0, parent?: FormItem): FormItem => {
+const buildPropItem = (componentId: string, prop: PropertyMeta, nodeProps: Record<string, unknown>, level = 0, parent?: FormItem, studioProp?: ResolvedStudioPropMeta): FormItem => {
   const key = prop.name
   const title = upperFirst(prop.name)
   const defaultValue: string | boolean | number | object | unknown[] | null = prop.tags?.find(tag => tag.name === 'defaultValue')?.text || ''
 
-  const { type, options } = computeTypeAndOptions(componentId, key, prop, level)
+  const { type, options } = computeTypeAndOptions(componentId, key, prop, level, studioProp)
 
   const isInsideArrayItem = parent?.id?.includes('#array/items')
 
+  // A multiple reference holds an array of values
+  const isMultipleReference = type === 'reference' && studioProp?.multiple === true
+  const conversionType = isMultipleReference ? 'array' : type
+
   // Format key based on type
-  const formattedKey = ['string', 'icon'].includes(type) || isInsideArrayItem ? key : `:${key}`
+  const plainKeyTypes = ['string', 'icon', 'media', 'textarea', 'date', 'datetime', 'reference']
+  const formattedKey = (plainKeyTypes.includes(type) && !isMultipleReference) || isInsideArrayItem ? key : `:${key}`
   const id = parent?.id
     ? `${parent?.id}/${formattedKey}`
     : `${componentId}/${formattedKey}`
@@ -267,12 +281,12 @@ const buildPropItem = (componentId: string, prop: PropertyMeta, nodeProps: Recor
 
   // Resolve default value
   const resolvedDefault = defaultValue !== undefined && defaultValue !== null
-    ? (typeof defaultValue === 'string' ? convertStringToValue(defaultValue, type) : defaultValue)
-    : generateDefault(type, level)
+    ? (typeof defaultValue === 'string' ? convertStringToValue(defaultValue, conversionType) : defaultValue)
+    : generateDefault(conversionType, level)
 
   // Convert string values and fallback to default
   const value = (typeof nodeValue === 'string'
-    ? convertStringToValue(nodeValue, type)
+    ? convertStringToValue(nodeValue, conversionType)
     : nodeValue)
   ?? resolvedDefault
 
@@ -284,6 +298,15 @@ const buildPropItem = (componentId: string, prop: PropertyMeta, nodeProps: Recor
     type,
     custom: false,
     default: resolvedDefault,
+  }
+
+  if (studioProp) {
+    if (studioProp.label !== undefined) propItem.label = studioProp.label
+    if (studioProp.description !== undefined) propItem.description = studioProp.description
+    if (studioProp.tooltip !== undefined) propItem.tooltip = studioProp.tooltip
+    if (studioProp.collection !== undefined) propItem.collection = studioProp.collection
+    if (studioProp.multiple !== undefined) propItem.multiple = studioProp.multiple
+    if (studioProp.field !== undefined) propItem.field = studioProp.field
   }
 
   // Handle array items schema
@@ -379,10 +402,16 @@ export const convertStringToArray = (string: string) => {
 // - `\'vertical\'` to 'vertical'
 // - 'boolean' to true or false
 // - number as string to number
-export const convertStringToValue = (string: string, type: JSType | 'icon') => {
+export const convertStringToValue = (string: string, type: FormInputsTypes) => {
   switch (type) {
     case 'icon':
       return string
+    case 'media':
+    case 'textarea':
+    case 'date':
+    case 'datetime':
+    case 'reference':
+      return string.replace(/^['"]|['"]$/g, '')
     case 'boolean':
       if (string === 'true') {
         return true
@@ -419,12 +448,16 @@ export const convertStringToValue = (string: string, type: JSType | 'icon') => {
   }
 }
 
-const computeTypeAndOptions = (componentId: string, key: string, prop: PropertyMeta, level: number) => {
-  let type: JSType | 'icon'
+const computeTypeAndOptions = (componentId: string, key: string, prop: PropertyMeta, level: number, studioProp?: ResolvedStudioPropMeta) => {
+  let type: FormInputsTypes
   const options: string[] = []
   const propType = typeof prop.schema === 'string' ? prop.schema.replace(' | undefined', '') : prop.schema?.type?.replace(' | undefined', '')
 
-  if (propType === 'boolean') {
+  // Studio annotations bypass all heuristics
+  if (studioProp?.input) {
+    type = studioProp.input
+  }
+  else if (propType === 'boolean') {
     type = 'boolean'
   }
   else if (propType === 'number') {
@@ -471,6 +504,15 @@ const computeTypeAndOptions = (componentId: string, key: string, prop: PropertyM
     options.push(...convertStringToArray(prop.type))
   }
 
+  // Studio explicit options override enum-derived options
+  if (studioProp?.options?.length) {
+    options.length = 0
+    options.push(...studioProp.options)
+  }
+  else if (type === 'icon' && studioProp?.iconLibraries?.length) {
+    options.push(...studioProp.iconLibraries)
+  }
+
   return { type, options }
 }
 
@@ -489,7 +531,7 @@ const hideProp = (prop: FormItem, isNuxtUIComponent: boolean) => {
   return false
 }
 
-const generateDefault = (type: JSType | 'icon', level = 0): string | boolean | number | [] | object | null => {
+const generateDefault = (type: FormInputsTypes, level = 0): string | boolean | number | [] | object | null => {
   if (type === 'array') {
     return level > 0 ? '' : []
   }

--- a/src/app/src/utils/tiptap/slots.ts
+++ b/src/app/src/utils/tiptap/slots.ts
@@ -1,0 +1,18 @@
+import type { ComponentMeta } from '../../types/editor'
+
+/**
+ * Display name and description for a component slot in the Studio UI,
+ * honoring `defineStudioMeta({ slots })` annotations.
+ */
+export function getSlotDisplay(componentMeta: ComponentMeta | undefined, slotName: string): { label: string, description?: string } {
+  const slotMeta = componentMeta?.meta.studio?.slots?.[slotName]
+
+  const display: { label: string, description?: string } = {
+    label: slotMeta?.label ?? slotName,
+  }
+  if (slotMeta?.description !== undefined) {
+    display.description = slotMeta.description
+  }
+
+  return display
+}

--- a/src/app/test/unit/component-meta.test.ts
+++ b/src/app/test/unit/component-meta.test.ts
@@ -1,0 +1,52 @@
+import { expect, test, describe } from 'vitest'
+import { ui, media, icon, textarea, date, datetime, select, collectionItem, hidden, defineStudioMeta } from '../../src/component-meta'
+
+describe('component-meta helpers', () => {
+  test('media returns a media input', () => {
+    expect(media()).toEqual({ input: 'media' })
+  })
+
+  test('icon returns an icon input, with optional libraries', () => {
+    expect(icon()).toEqual({ input: 'icon' })
+    expect(icon({ libraries: ['lucide', 'simple-icons'] })).toEqual({ input: 'icon', iconLibraries: ['lucide', 'simple-icons'] })
+  })
+
+  test('textarea, date and datetime return their input type', () => {
+    expect(textarea()).toEqual({ input: 'textarea' })
+    expect(date()).toEqual({ input: 'date' })
+    expect(datetime()).toEqual({ input: 'datetime' })
+  })
+
+  test('select returns explicit options', () => {
+    expect(select({ options: ['primary', 'secondary'] })).toEqual({ options: ['primary', 'secondary'] })
+  })
+
+  test('collectionItem returns a reference input', () => {
+    expect(collectionItem({ collection: 'authors' })).toEqual({ input: 'reference', collection: 'authors' })
+    expect(collectionItem({ collection: 'articles', multiple: true, field: 'path' }))
+      .toEqual({ input: 'reference', collection: 'articles', multiple: true, field: 'path' })
+  })
+
+  test('hidden returns a hidden prop', () => {
+    expect(hidden()).toEqual({ hidden: true })
+  })
+
+  test('ui merges display metadata with a type helper', () => {
+    expect(ui({ label: 'Image source', description: 'Pick a cool image', type: media() }))
+      .toEqual({ label: 'Image source', description: 'Pick a cool image', input: 'media' })
+  })
+
+  test('ui works without a type and keeps tooltip/hidden', () => {
+    expect(ui({ label: 'Internal', tooltip: 'Not shown', hidden: true }))
+      .toEqual({ label: 'Internal', tooltip: 'Not shown', hidden: true })
+  })
+
+  test('ui does not emit undefined display keys', () => {
+    expect(ui({ type: collectionItem({ collection: 'authors' }) }))
+      .toEqual({ input: 'reference', collection: 'authors' })
+  })
+
+  test('defineStudioMeta is a no-op', () => {
+    expect(defineStudioMeta({ props: { icon: icon() } })).toBeUndefined()
+  })
+})

--- a/src/app/test/unit/utils/form.test.ts
+++ b/src/app/test/unit/utils/form.test.ts
@@ -1093,3 +1093,73 @@ describe('getUpdatedTreeItem', () => {
     expect(getUpdatedTreeItem(farnabazFormTree, farnabazFormTree)).toBeNull()
   })
 })
+
+describe('studio editor annotations', () => {
+  const wrapSchema = (properties: Record<string, unknown>): Draft07 => ({
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    $ref: '#/definitions/posts',
+    definitions: {
+      posts: {
+        type: 'object',
+        properties,
+        additionalProperties: false,
+        required: [],
+      },
+    },
+  } as unknown as Draft07)
+
+  test('reference editor input carries collection and field', () => {
+    const schema = wrapSchema({
+      author: {
+        type: 'string',
+        $content: { editor: { input: 'reference', collection: 'authors', field: 'stem' } },
+      },
+    })
+
+    const tree = buildFormTreeFromSchema('posts', schema)
+
+    expect(tree.posts!.children!.author).toMatchObject({
+      type: 'reference',
+      collection: 'authors',
+      field: 'stem',
+    })
+  })
+
+  test('reference editor input on an array renders a multiple reference, not an array form', () => {
+    const schema = wrapSchema({
+      related: {
+        type: 'array',
+        items: { type: 'string' },
+        $content: { editor: { input: 'reference', collection: 'articles', multiple: true } },
+      },
+    })
+
+    const tree = buildFormTreeFromSchema('posts', schema)
+
+    expect(tree.posts!.children!.related).toMatchObject({
+      type: 'reference',
+      collection: 'articles',
+      multiple: true,
+    })
+    expect(tree.posts!.children!.related!.arrayItemForm).toBeUndefined()
+  })
+
+  test('explicit editor options override enum values', () => {
+    const schema = wrapSchema({
+      variant: {
+        type: 'string',
+        enum: ['x', 'y'],
+        $content: { editor: { options: ['primary', 'secondary'] } },
+      },
+      plain: {
+        type: 'string',
+        $content: { editor: { options: ['a', 'b'] } },
+      },
+    })
+
+    const tree = buildFormTreeFromSchema('posts', schema)
+
+    expect(tree.posts!.children!.variant!.options).toEqual(['primary', 'secondary'])
+    expect(tree.posts!.children!.plain!.options).toEqual(['a', 'b'])
+  })
+})

--- a/src/app/test/unit/utils/tiptap/props.test.ts
+++ b/src/app/test/unit/utils/tiptap/props.test.ts
@@ -1493,4 +1493,188 @@ describe('props', () => {
       expect(out.src).toBe('authored.mp4')
     })
   })
+
+  describe('studio annotations (defineStudioMeta)', () => {
+    const stringProp = (name: string, overrides: Partial<PropertyMeta> = {}): PropertyMeta => ({
+      name,
+      global: false,
+      description: '',
+      tags: [],
+      required: false,
+      type: 'string | undefined',
+      schema: {
+        kind: 'enum',
+        type: 'string | undefined',
+        schema: ['undefined', 'string'],
+      },
+      declarations: [],
+      getDeclarations: () => [],
+      getTypeObject: {} as never,
+      ...overrides,
+    })
+
+    const createStudioComponentMeta = (
+      props: PropertyMeta[],
+      studio: NonNullable<ComponentMeta['meta']['studio']>,
+      options: { nuxtUI?: boolean } = {},
+    ): ComponentMeta => ({
+      name: 'AuthorCard',
+      path: '/path/to/AuthorCard.vue',
+      nuxtUI: options.nuxtUI ?? false,
+      meta: {
+        props,
+        slots: [],
+        events: [],
+        studio,
+      },
+    })
+
+    const createNode = (props: Record<string, unknown> = {}): ProseMirrorNode => ({
+      type: { name: 'element' },
+      attrs: { tag: 'AuthorCard', props },
+    } as unknown as ProseMirrorNode)
+
+    test('input override beats heuristics and keeps a plain key for string-like inputs', () => {
+      const meta = createStudioComponentMeta(
+        [stringProp('cover'), stringProp('bio'), stringProp('publishedAt')],
+        {
+          props: {
+            cover: { input: 'media' },
+            bio: { input: 'textarea' },
+            publishedAt: { input: 'date' },
+          },
+        },
+      )
+
+      const tree = buildFormTreeFromProps(createNode({ cover: '/img/cover.png' }), meta)
+
+      expect(tree.cover).toMatchObject({ key: 'cover', type: 'media', value: '/img/cover.png' })
+      expect(tree.bio).toMatchObject({ key: 'bio', type: 'textarea' })
+      expect(tree.publishedAt).toMatchObject({ key: 'publishedAt', type: 'date' })
+    })
+
+    test('icon input picks up iconLibraries as options', () => {
+      const meta = createStudioComponentMeta(
+        [stringProp('symbol')],
+        { props: { symbol: { input: 'icon', iconLibraries: ['lucide', 'simple-icons'] } } },
+      )
+
+      const tree = buildFormTreeFromProps(createNode(), meta)
+
+      expect(tree.symbol).toMatchObject({ type: 'icon', options: ['lucide', 'simple-icons'] })
+    })
+
+    test('explicit options override enum extraction', () => {
+      const enumProp = stringProp('variant', {
+        type: '"primary" | "secondary" | undefined',
+        schema: {
+          kind: 'enum',
+          type: '"primary" | "secondary" | undefined',
+          schema: ['undefined', 'primary', 'secondary'],
+        },
+      })
+      const meta = createStudioComponentMeta(
+        [enumProp],
+        { props: { variant: { options: ['primary', 'secondary', 'ghost'] } } },
+      )
+
+      const tree = buildFormTreeFromProps(createNode(), meta)
+
+      expect(tree.variant!.options).toEqual(['primary', 'secondary', 'ghost'])
+    })
+
+    test('label, description and tooltip land on the form item', () => {
+      const meta = createStudioComponentMeta(
+        [stringProp('cover')],
+        { props: { cover: { label: 'Cover image', description: 'Shown on top', tooltip: 'Use landscape' } } },
+      )
+
+      const tree = buildFormTreeFromProps(createNode(), meta)
+
+      expect(tree.cover).toMatchObject({ label: 'Cover image', description: 'Shown on top', tooltip: 'Use landscape' })
+    })
+
+    test('hidden: true hides a prop, hidden: false un-hides a HIDDEN_PROPS entry', () => {
+      const meta = createStudioComponentMeta(
+        [stringProp('internal'), stringProp('disabled')],
+        {
+          props: {
+            internal: { hidden: true },
+            disabled: { hidden: false },
+          },
+        },
+        { nuxtUI: true },
+      )
+
+      const tree = buildFormTreeFromProps(createNode(), meta)
+
+      expect(tree.internal!.hidden).toBe(true)
+      // `disabled` is in HIDDEN_PROPS and would be hidden on a Nuxt UI component
+      expect(tree.disabled!.hidden).toBeUndefined()
+    })
+
+    test('single reference keeps a plain key, stores a string and carries picker options', () => {
+      const meta = createStudioComponentMeta(
+        [stringProp('authorId')],
+        { props: { authorId: { input: 'reference', collection: 'authors', field: 'stem' } } },
+      )
+
+      const tree = buildFormTreeFromProps(createNode({ authorId: 'authors/john-doe' }), meta)
+
+      expect(tree.authorId).toMatchObject({
+        key: 'authorId',
+        type: 'reference',
+        value: 'authors/john-doe',
+        collection: 'authors',
+        field: 'stem',
+      })
+    })
+
+    test('multiple reference uses an interpreted key, stores an array and defaults to []', () => {
+      const meta = createStudioComponentMeta(
+        [stringProp('related'), stringProp('tags')],
+        {
+          props: {
+            related: { input: 'reference', collection: 'articles', multiple: true },
+            tags: { input: 'reference', collection: 'tags', multiple: true },
+          },
+        },
+      )
+
+      const tree = buildFormTreeFromProps(
+        createNode({ ':related': ['articles/one', 'articles/two'] }),
+        meta,
+      )
+
+      expect(tree[':related']).toMatchObject({
+        key: ':related',
+        type: 'reference',
+        value: ['articles/one', 'articles/two'],
+        collection: 'articles',
+        multiple: true,
+      })
+      expect(tree[':tags']).toMatchObject({ key: ':tags', value: [], default: [] })
+    })
+
+    test('multiple reference parses a JSON string node value', () => {
+      const meta = createStudioComponentMeta(
+        [stringProp('related')],
+        { props: { related: { input: 'reference', collection: 'articles', multiple: true } } },
+      )
+
+      const tree = buildFormTreeFromProps(
+        createNode({ ':related': '["articles/one"]' }),
+        meta,
+      )
+
+      expect(tree[':related']!.value).toEqual(['articles/one'])
+    })
+
+    test('convertStringToValue handles the studio input types', () => {
+      expect(convertStringToValue('/img/a.png', 'media')).toEqual('/img/a.png')
+      expect(convertStringToValue('"quoted"', 'textarea')).toEqual('quoted')
+      expect(convertStringToValue('2026-07-01', 'date')).toEqual('2026-07-01')
+      expect(convertStringToValue('authors/john', 'reference')).toEqual('authors/john')
+    })
+  })
 })

--- a/src/app/test/unit/utils/tiptap/slots.test.ts
+++ b/src/app/test/unit/utils/tiptap/slots.test.ts
@@ -1,0 +1,34 @@
+import { expect, test, describe } from 'vitest'
+import { getSlotDisplay } from '../../../../src/utils/tiptap/slots'
+import type { ComponentMeta } from '../../../../src/types/editor'
+
+describe('getSlotDisplay', () => {
+  const componentMeta: ComponentMeta = {
+    name: 'AuthorCard',
+    path: '/path/to/AuthorCard.vue',
+    meta: {
+      props: [],
+      slots: [],
+      events: [],
+      studio: {
+        slots: {
+          title: { label: 'Heading' },
+          description: { label: 'Short description', description: 'Displayed under the title' },
+        },
+      },
+    },
+  }
+
+  test('returns the studio label and description when annotated', () => {
+    expect(getSlotDisplay(componentMeta, 'title')).toEqual({ label: 'Heading' })
+    expect(getSlotDisplay(componentMeta, 'description')).toEqual({
+      label: 'Short description',
+      description: 'Displayed under the title',
+    })
+  })
+
+  test('falls back to the slot name when not annotated', () => {
+    expect(getSlotDisplay(componentMeta, 'footer')).toEqual({ label: 'footer' })
+    expect(getSlotDisplay(undefined, 'default')).toEqual({ label: 'default' })
+  })
+})

--- a/src/app/vite.config.ts
+++ b/src/app/vite.config.ts
@@ -77,7 +77,7 @@ export default defineConfig(({ mode }) => ({
     cssCodeSplit: false,
     outDir: '../../dist/app',
     lib: {
-      entry: ['./src/main.ts', './src/shared.ts', './src/service-worker.ts'],
+      entry: ['./src/main.ts', './src/shared.ts', './src/service-worker.ts', './src/component-meta.ts'],
       formats: ['es'],
     },
     sourcemap: false,

--- a/src/module/src/module.ts
+++ b/src/module/src/module.ts
@@ -1,4 +1,4 @@
-import { defineNuxtModule, createResolver, addPlugin, extendViteConfig, addServerHandler, addServerImports, useLogger, hasNuxtModule } from '@nuxt/kit'
+import { defineNuxtModule, createResolver, addPlugin, addTypeTemplate, extendViteConfig, addServerHandler, addServerImports, useLogger, hasNuxtModule } from '@nuxt/kit'
 import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { defu } from 'defu'
@@ -460,6 +460,29 @@ export default defineNuxtModule<ModuleOptions>({
     const resolver = createResolver(import.meta.url)
     const runtime = (...args: string[]) => resolver.resolve('./runtime', ...args)
     const editorOptions = options.editor ?? options.meta
+
+    // Register the `defineStudioMeta` compiler macro on nuxt-component-meta
+    // (installed by @nuxt/content). defu array-merge keeps the module's
+    // built-in `extendComponentMeta` default alongside ours.
+    const nuxtOptions = nuxt.options as typeof nuxt.options & {
+      componentMeta?: { extendMetaFunctions?: Array<{ name: string, transform?: (extracted: Record<string, unknown>) => Record<string, unknown> }> }
+    }
+    nuxtOptions.componentMeta = defu(nuxtOptions.componentMeta, {
+      extendMetaFunctions: [
+        { name: 'defineStudioMeta', transform: (extracted: Record<string, unknown>) => ({ studio: extracted }) },
+      ],
+    })
+
+    addTypeTemplate({
+      filename: 'types/studio-macros.d.ts',
+      getContents: () => [
+        'declare global {',
+        '  function defineStudioMeta(meta: import(\'nuxt-studio/app\').StudioComponentMeta): void',
+        '}',
+        'export {}',
+        '',
+      ].join('\n'),
+    })
 
     addServerImports([
       {

--- a/src/module/src/runtime/server/routes/meta.ts
+++ b/src/module/src/runtime/server/routes/meta.ts
@@ -5,7 +5,7 @@ import components from '#nuxt-component-meta/nitro'
 import type { ComponentMeta as VueComponentMeta } from 'vue-component-meta'
 // @ts-expect-error import does exist
 import { highlight } from '#mdc-imports'
-import type { ComponentMeta } from 'nuxt-studio/app'
+import type { ComponentMeta, StudioComponentMeta } from 'nuxt-studio/app'
 import { filterComponents } from '../utils/meta'
 import { requireStudioAuth } from '../utils/auth'
 
@@ -30,6 +30,7 @@ export default eventHandler(async (event) => {
           props: meta.props,
           slots: meta.slots,
           events: meta.events,
+          studio: (meta as VueComponentMeta & { studio?: StudioComponentMeta }).studio,
         },
       }
     })


### PR DESCRIPTION
> [!CAUTION]
> This is very early stage, and primarily serves a PoC for things to come. 

Adds a `defineStudioMeta` compiler macro (via nuxt-component-meta [#116](https://github.com/nuxt-content/nuxt-component-meta/pull/116)) to annotate component props and slots for the Studio editor, plus typed helpers under `nuxt-studio/component-meta` and a new collection `reference` input (single + multiple).

```vue
<script setup lang="ts">
import { defineStudioMeta, ui, media, icon, select, collectionItem, hidden } from 'nuxt-studio/component-meta'

defineStudioMeta({
  props: {
    cover: ui({ label: 'Cover image', type: media() }),
    author: collectionItem({ collection: 'authors', field: 'stem' }),
    variant: select({ options: ['default', 'outlined'] }),
    internal: hidden(),
  },
  slots: {
    title: { label: 'Heading' },
  },
})
</script>
```

Demo: `playground/docus` → `AuthorCard` component on the `/pages/author-card` page.

Depends on the pkg.pr.new build of nuxt-component-meta#116 (pinned via pnpm override).

Closes #129, closes #436