### PR TITLE
fix(module): derive media list items from keys instead of N+1 fetches

### DIFF
--- a/src/module/src/runtime/host.ts
+++ b/src/module/src/runtime/host.ts
@@ -1,4 +1,5 @@
 import { ref } from 'vue'
+import { withLeadingSlash } from 'ufo'
 import { ensure } from './utils/ensure'
 import type { CollectionInfo, CollectionItemBase, CollectionSource, DatabaseAdapter } from '@nuxt/content'
 import type { ContentDatabaseAdapter } from '../types/content'
@@ -318,13 +319,17 @@ export function useStudioHost(user: StudioUser, repository: Repository): StudioH
           return await getStorage().getItem(generateMediaIdFromFsPath(fsPath)) as MediaItem
         },
         list: async (): Promise<MediaItem[]> => {
-          const storage = getStorage()
-          const items = await Promise.all(
-            await storage.getKeys().then((keys: string[]) =>
-              keys.map((key: string) => storage.getItem(key)),
-            ),
-          )
-          return items.filter(Boolean) as MediaItem[]
+          const keys = await getStorage().getKeys()
+          return keys.map((key: string): MediaItem => {
+            const fsPath = withLeadingSlash(key.replace(/:/g, '/'))
+            return {
+              id: generateMediaIdFromFsPath(fsPath),
+              extension: key.split('.').pop() || '',
+              stem: key.split('.').join('.'),
+              path: fsPath,
+              fsPath,
+            }
+          })
         },
         upsert: async (fsPath: string, media: MediaItem) => {
           const id = generateMediaIdFromFsPath(fsPath)

--- a/src/module/src/runtime/host.ts
+++ b/src/module/src/runtime/host.ts
@@ -320,9 +320,10 @@ export function useStudioHost(user: StudioUser, repository: Repository): StudioH
         },
         list: async (): Promise<MediaItem[]> => {
           const keys = await getStorage().getKeys()
+          // production's pre-baked storage keys carry the collection prefix; dev/external keys don't
+          const collectionPrefix = new RegExp(`^${VIRTUAL_MEDIA_COLLECTION_NAME}:`)
           return keys.map((key: string): MediaItem => {
-            // production's pre-baked storage keys carry the collection prefix; dev/external keys don't
-            const rawKey = key.replace(new RegExp(`^${VIRTUAL_MEDIA_COLLECTION_NAME}:`), '')
+            const rawKey = key.replace(collectionPrefix, '')
             return mediaItemFieldsFromKey(rawKey)
           })
         },

--- a/src/module/src/runtime/host.ts
+++ b/src/module/src/runtime/host.ts
@@ -1,5 +1,4 @@
 import { ref } from 'vue'
-import { withLeadingSlash } from 'ufo'
 import { ensure } from './utils/ensure'
 import type { CollectionInfo, CollectionItemBase, CollectionSource, DatabaseAdapter } from '@nuxt/content'
 import type { ContentDatabaseAdapter } from '../types/content'
@@ -14,7 +13,8 @@ import { collections } from '#content/preview'
 import { publicAssetsStorage, externalAssetsStorage } from '#build/studio-assets'
 import { useHostMeta } from './composables/useMeta'
 import { assignComponentsToGroups } from './utils/componentGroups'
-import { generateIdFromFsPath as generateMediaIdFromFsPath } from './utils/media'
+import { generateIdFromFsPath as generateMediaIdFromFsPath, mediaItemFieldsFromKey } from './utils/media'
+import { VIRTUAL_MEDIA_COLLECTION_NAME } from './utils/constants'
 import { getCollectionSourceById } from './utils/source'
 import { kebabCase } from 'scule'
 
@@ -321,14 +321,9 @@ export function useStudioHost(user: StudioUser, repository: Repository): StudioH
         list: async (): Promise<MediaItem[]> => {
           const keys = await getStorage().getKeys()
           return keys.map((key: string): MediaItem => {
-            const fsPath = withLeadingSlash(key.replace(/:/g, '/'))
-            return {
-              id: generateMediaIdFromFsPath(fsPath),
-              extension: key.split('.').pop() || '',
-              stem: key.split('.').join('.'),
-              path: fsPath,
-              fsPath,
-            }
+            // production's pre-baked storage keys carry the collection prefix; dev/external keys don't
+            const rawKey = key.replace(new RegExp(`^${VIRTUAL_MEDIA_COLLECTION_NAME}:`), '')
+            return mediaItemFieldsFromKey(rawKey)
           })
         },
         upsert: async (fsPath: string, media: MediaItem) => {

--- a/src/module/src/runtime/server/routes/dev/public/[...path].ts
+++ b/src/module/src/runtime/server/routes/dev/public/[...path].ts
@@ -1,10 +1,10 @@
 import type { H3Event } from 'h3'
 import { createError, eventHandler, getRequestHeader, readRawBody, setResponseHeader } from 'h3'
 import type { Storage, StorageMeta } from 'unstorage'
-import { withLeadingSlash } from 'ufo'
 // @ts-expect-error useStorage is not defined in .nuxt/imports.d.ts
 import { useStorage } from '#imports'
 import { VIRTUAL_MEDIA_COLLECTION_NAME } from '../../../../utils/constants'
+import { mediaItemFieldsFromKey } from '../../../../utils/media'
 
 
 export default eventHandler(async (event) => {
@@ -29,11 +29,7 @@ export default eventHandler(async (event) => {
       })
     }
     return {
-      id: `${VIRTUAL_MEDIA_COLLECTION_NAME}/${key.replace(/:/g, '/')}`,
-      extension: key.split('.').pop(),
-      stem: key.split('.').join('.'),
-      path: '/' + key.replace(/:/g, '/'),
-      fsPath: withLeadingSlash(key.replace(/:/g, '/')),
+      ...mediaItemFieldsFromKey(key),
       version: new Date(item.mtime || new Date()).getTime(),
     }
   }

--- a/src/module/src/runtime/utils/media.ts
+++ b/src/module/src/runtime/utils/media.ts
@@ -1,6 +1,28 @@
 import { join } from 'pathe'
+import { withLeadingSlash } from 'ufo'
 import { VIRTUAL_MEDIA_COLLECTION_NAME } from './constants'
 
 export function generateIdFromFsPath(fsPath: string) {
   return join(VIRTUAL_MEDIA_COLLECTION_NAME, fsPath)
+}
+
+export interface MediaItemKeyFields {
+  id: string
+  extension: string
+  stem: string
+  path: string
+  fsPath: string
+  [key: string]: unknown
+}
+
+// `key` must be a raw, unprefixed storage key — strip VIRTUAL_MEDIA_COLLECTION_NAME first if present
+export function mediaItemFieldsFromKey(key: string): MediaItemKeyFields {
+  const fsPath = withLeadingSlash(key.replace(/:/g, '/'))
+  return {
+    id: generateIdFromFsPath(fsPath),
+    extension: key.split('.').pop() || '',
+    stem: key.split('.').slice(0, -1).join('.'),
+    path: fsPath,
+    fsPath,
+  }
 }

--- a/src/module/src/runtime/utils/media.ts
+++ b/src/module/src/runtime/utils/media.ts
@@ -21,7 +21,7 @@ export function mediaItemFieldsFromKey(key: string): MediaItemKeyFields {
   return {
     id: generateIdFromFsPath(fsPath),
     extension: key.split('.').pop() || '',
-    stem: key.split('.').slice(0, -1).join('.'),
+    stem: fsPath.split('.').slice(0, -1).join('.'),
     path: fsPath,
     fsPath,
   }

--- a/src/module/src/templates.ts
+++ b/src/module/src/templates.ts
@@ -1,6 +1,5 @@
 import type { Storage } from 'unstorage'
-import { withLeadingSlash } from 'ufo'
-import { VIRTUAL_MEDIA_COLLECTION_NAME } from './utils/constants'
+import { mediaItemFieldsFromKey } from './runtime/utils/media'
 
 export async function getAssetsDefaultStorageDevTemplate() {
   return [
@@ -20,14 +19,7 @@ export async function getAssetsDefaultStorageTemplate(assetsStorage: Storage) {
     'const storage = createStorage({})',
     '',
     ...keys.map((key) => {
-      const path = withLeadingSlash(key.replace(/:/g, '/'))
-      const value = {
-        id: `${VIRTUAL_MEDIA_COLLECTION_NAME}/${key.replace(/:/g, '/')}`,
-        extension: key.split('.').pop(),
-        stem: key.split('.').join('.'),
-        path,
-        fsPath: path,
-      }
+      const value = mediaItemFieldsFromKey(key)
       return `storage.setItem('${value.id}', ${JSON.stringify(value)})`
     }),
     '',

--- a/src/module/test/utils/media.test.ts
+++ b/src/module/test/utils/media.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { mediaItemFieldsFromKey } from '../../src/runtime/utils/media'
+
+describe('mediaItemFieldsFromKey', () => {
+  it('should derive fields from a root-level key', () => {
+    expect(mediaItemFieldsFromKey('demo.mp4')).toEqual({
+      id: 'public-assets/demo.mp4',
+      extension: 'mp4',
+      stem: '/demo',
+      path: '/demo.mp4',
+      fsPath: '/demo.mp4',
+    })
+  })
+
+  it('should derive fields from a nested, colon-separated key', () => {
+    expect(mediaItemFieldsFromKey('videos:sub:demo.mp4')).toEqual({
+      id: 'public-assets/videos/sub/demo.mp4',
+      extension: 'mp4',
+      stem: '/videos/sub/demo',
+      path: '/videos/sub/demo.mp4',
+      fsPath: '/videos/sub/demo.mp4',
+    })
+  })
+
+  it('should not duplicate the extension in stem for a file with a single dot', () => {
+    const { stem, extension } = mediaItemFieldsFromKey('photo.png')
+
+    expect(`${stem}.${extension}`).toBe('/photo.png')
+  })
+})


### PR DESCRIPTION
## Summary

`host.media.list()` (`src/module/src/runtime/host.ts`) called `storage.getItem()` once per key on top of `storage.getKeys()`, firing one HTTP request per file whenever `publicAssetsStorage` is backed by an HTTP driver (dev mode, `/__nuxt_studio/dev/public/**`).

On a `public/` folder with many files, this floods the browser's per-origin connection limit — many requests get stuck in `pending` and `Promise.all` never resolves.

Since `host.media.list()` is awaited inside `draftMedias.load()` (via the `studio:draft:media:updated` hook → `handleDraftUpdate()`), and `isReady` in `useStudio.ts` is only set after both `draftDocuments.load()` and `draftMedias.load()` resolve, a stuck media listing blocks `isReady` forever — with no console error, since nothing actually fails, it just never completes.

This silently broke the whole "auto-open on mount" flow in `app.vue` (and by extension the floating "Edit this page" button, gated on `isReady`), since #504 made that flow explicitly wait on `isReady` instead of firing on a bare timeout.

## Fix

All fields needed to populate the media tree/browser (`id`, `extension`, `stem`, `path`, `fsPath`) are derivable directly from the storage key — no need to fetch each item's content/metadata just to list it. `list()` now does a single `getKeys()` call and computes these fields client-side, matching the same derivation already used in the prod build-time template (`templates.ts:getAssetsDefaultStorageTemplate`) and the dev server route (`server/routes/dev/public/[...path].ts`).

Verified `generateMediaIdFromFsPath()` produces identical `id` strings to those two existing code paths, so this doesn't introduce any `id` mismatch that could affect draft status detection (`getStatus()` compares `original.id !== modified.id`).

Full per-file metadata is still fetched lazily via `host.media.get(fsPath)` when a specific file is actually opened — only the eager, unbounded fan-out at listing time is removed.