### PR TITLE
fix(app): await implicit reselect to prevent selection race after creating a document

### DIFF
--- a/src/app/src/composables/useTree.ts
+++ b/src/app/src/composables/useTree.ts
@@ -155,7 +155,7 @@ export const useTree = (type: StudioFeature, host: StudioHost, draft: ReturnType
     if (selectItem) {
       const item = findItemFromFsPath(tree.value, currentItem.value.fsPath)
       if (item) {
-        select(item)
+        await select(item)
       }
       else if (currentItem.value.type !== 'root') {
         await selectParentByFsPath(currentItem.value.fsPath)


### PR DESCRIPTION
## Summary
- After creating a new document from inside a folder, the editor sometimes bounced back to the folder/file-list view and the host preview never navigated to the new page.
- Root cause: `handleDraftUpdate`'s implicit "reselect whatever was already open" branch called `select(item)` without `await`. Since this runs inside the same hook chain that `CreateDocument` awaits, the dangling promise could resolve *after* `CreateDocument`'s own explicit `selectItemByFsPath(newFile)` call and clobber `currentItem`/`draft.current` back to the previous item.
- Fix: `await` that call, matching its sibling `selectParentByFsPath` branch right below it. This guarantees the implicit resync always completes before any caller-level explicit reselect runs, removing the race without changing behavior for Revert/Rename/Delete which rely on this implicit resync.
