### PR TITLE
fix(tiptap): match camelCase meta props to kebab-cased stored attrs

### DIFF
--- a/src/app/src/utils/tiptap/comarkToTiptap.ts
+++ b/src/app/src/utils/tiptap/comarkToTiptap.ts
@@ -2,7 +2,7 @@ import type { JSONContent } from '@tiptap/vue-3'
 import { isEmpty } from '../../utils/object'
 import type { ComarkTree, ComarkNode, ComarkElement, ComarkComment } from 'comark'
 import { EMOJI_REGEXP, getEmojiUnicode } from '../emoji'
-import { isValidAttr } from './props'
+import { isValidAttr, stripBindingPrefix } from './props'
 import { isElement, isComment, getTag, getAttrs, getChildren } from '../comark'
 import { sameMark, type MarkInfo } from './tiptapToComark'
 
@@ -265,8 +265,7 @@ function createVideoTipTapNode(node: ComarkElement): JSONContent {
 
   // Normalize boolean properties from string "true"/"false" to actual booleans
   const normalizedProps = Object.entries(props).reduce((acc, [key, value]) => {
-    // Remove ':' prefix if present
-    const cleanKey = key.startsWith(':') ? key.substring(1) : key
+    const cleanKey = stripBindingPrefix(key)
 
     if (booleanProps.includes(cleanKey)) {
       if (value === 'true' || value === true) {

--- a/src/app/src/utils/tiptap/props.ts
+++ b/src/app/src/utils/tiptap/props.ts
@@ -1,4 +1,4 @@
-import { flatCase, pascalCase, titleCase, upperFirst } from 'scule'
+import { flatCase, kebabCase, pascalCase, titleCase, upperFirst } from 'scule'
 import { hasProtocol, isRelative } from 'ufo'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import type { JSType } from 'untyped'
@@ -155,6 +155,18 @@ export function normalizeProps(nodeProps: Record<string, unknown>, extraProps: o
   return out
 }
 
+export const stripBindingPrefix = (key: string): string => (key.startsWith(':') ? key.slice(1) : key)
+
+// Stored attrs may be kebab-cased while meta declares props in camelCase (e.g. `foo-bar` vs `fooBar`)
+const resolveNodePropValue = (nodeProps: Record<string, unknown>, key: string): unknown => {
+  if (key in nodeProps) return nodeProps[key]
+  if (`:${key}` in nodeProps) return nodeProps[`:${key}`]
+
+  const normalizedKey = kebabCase(key)
+  const rawKey = Object.keys(nodeProps).find(k => kebabCase(stripBindingPrefix(k)) === normalizedKey)
+  return rawKey ? nodeProps[rawKey] : undefined
+}
+
 export const buildFormTreeFromProps = (node: ProseMirrorNode, componentMeta: ComponentMeta): FormTree => {
   const isNuxtUIComponent = componentMeta.nuxtUI ?? false
   const props = componentMeta.meta.props
@@ -181,9 +193,10 @@ export const buildFormTreeFromProps = (node: ProseMirrorNode, componentMeta: Com
   }
 
   // Add custom props added manually by user
+  const existingKeys = new Set(Object.keys(formTree).map(k => kebabCase(stripBindingPrefix(k))))
+  const isKnownProp = (key: string): boolean => existingKeys.has(kebabCase(stripBindingPrefix(key)))
   for (const key in nodeProps) {
-    // Skip props already added from meta
-    if (formTree[key] || formTree[`:${key}`]) {
+    if (isKnownProp(key)) {
       continue
     }
 
@@ -260,10 +273,9 @@ const buildPropItem = (componentId: string, prop: PropertyMeta, nodeProps: Recor
     ? `${parent?.id}/${formattedKey}`
     : `${componentId}/${formattedKey}`
 
-  // Get node value: from parent object, direct prop, or interpreted prop (`:key`)
   const nodeValue = (parent?.type === 'object' && parent?.value)
     ? (parent.value as Record<string, unknown>)[key]
-    : nodeProps[key] ?? nodeProps[`:${key}`]
+    : resolveNodePropValue(nodeProps, key)
 
   // Resolve default value
   const resolvedDefault = defaultValue !== undefined && defaultValue !== null

--- a/src/app/test/unit/utils/tiptap/props.test.ts
+++ b/src/app/test/unit/utils/tiptap/props.test.ts
@@ -1277,6 +1277,64 @@ describe('props', () => {
       })
     })
 
+    test('binds a camelCase meta prop to its differently-cased stored attr instead of duplicating it (issue #529)', () => {
+      const props: PropertyMeta[] = [
+        {
+          name: 'fooBar',
+          global: false,
+          description: '',
+          tags: [],
+          required: false,
+          type: 'string | undefined',
+          schema: 'string | undefined',
+          declarations: [],
+        },
+        {
+          name: 'bazQux',
+          global: false,
+          description: '',
+          tags: [],
+          required: false,
+          type: 'string | undefined',
+          schema: 'string | undefined',
+          declarations: [],
+        },
+        {
+          name: 'quuxCorge',
+          global: false,
+          description: '',
+          tags: [],
+          required: false,
+          type: 'string | undefined',
+          schema: 'string | undefined',
+          declarations: [],
+        },
+      ]
+
+      const node = {
+        type: {
+          name: 'element',
+        },
+        attrs: {
+          tag: 'Unicorn',
+          props: {
+            'foo-bar': 'foo bar value', // kebab-case, as produced by the MDC parser
+            'baz_qux': 'baz qux value', // snake_case
+            'QuuxCorge': 'quux corge value', // PascalCase
+          },
+        },
+      } as unknown as ProseMirrorNode
+
+      const formTree = buildFormTreeFromProps(node, createComponentMeta(props))
+
+      // One field per declared prop, bound to the stored value — no empty meta field
+      // plus a duplicate "custom" field for the differently-cased key.
+      expect(Object.keys(formTree)).toEqual(['fooBar', 'bazQux', 'quuxCorge'])
+      expect(formTree.fooBar).toMatchObject({ key: 'fooBar', value: 'foo bar value', custom: false })
+      expect(formTree.bazQux).toMatchObject({ key: 'bazQux', value: 'baz qux value', custom: false })
+      expect(formTree.quuxCorge).toMatchObject({ key: 'quuxCorge', value: 'quux corge value', custom: false })
+    })
+
     // test('generate props for video component', () => {
     //   const props: PropertyMeta[] = []
 


### PR DESCRIPTION
## Summary

Fixes #529 - Studio was corrupting MDC component props (duplicate fields in the props editor, values silently dropped/rewritten).

**Root cause**: the MDC parser stores component props in kebab-case (e.g. `cite-name`), while `nuxt-component-meta` declares them in camelCase (e.g. `citeName`). `buildFormTreeFromProps` in `src/app/src/utils/tiptap/props.ts` matched these with exact string equality:
- The meta-declared field's value lookup never found the kebab-cased stored value → rendered empty.
- The stored kebab-cased key wasn't recognized as already covered by the meta field → added again as a duplicate "custom" field.