### PR TITLE
fix(media): release the upload action when the file picker closes

### DIFF
--- a/src/app/src/components/shared/item/ItemActionsToolbar.vue
+++ b/src/app/src/components/shared/item/ItemActionsToolbar.vue
@@ -116,6 +116,7 @@ onUnmounted(() => {
       :accept="MEDIA_EXTENSIONS.map(ext => `.${ext}`).join(', ')"
       class="hidden"
       @change="handleFileSelection"
+      @cancel="context.unsetActionInProgress()"
     >
   </div>
 </template>

--- a/src/app/src/composables/useContext.ts
+++ b/src/app/src/composables/useContext.ts
@@ -159,6 +159,8 @@ export const useContext = createSharedComposable((
       for (const file of files) {
         await (activeTree.value.draft as ReturnType<typeof useDraftMedias>).upload(parentFsPath, file)
       }
+
+      unsetActionInProgress()
     },
     [StudioItemActionId.RevertItem]: async (item: TreeItem) => {
       await activeTree.value.draft.revert(item.fsPath)

--- a/src/app/test/integration/actions.test.ts
+++ b/src/app/test/integration/actions.test.ts
@@ -765,6 +765,25 @@ describe('Media - Action Chains Integration Tests', () => {
     expect(consoleInfoSpy).toHaveBeenCalledWith('studio:draft:media:updated have been called by', 'useDraftBase.revert')
   })
 
+  it('Upload > Upload releases the action so the file picker can reopen', async () => {
+    const uploadAction = () => context.itemActions.value.find(action => action.id === StudioItemActionId.UploadMedia)!
+
+    /* STEP 1: TRIGGER UPLOAD - the action stays in progress while the file picker is open */
+    await uploadAction().handler!({ parentFsPath: parentPath, files: [] })
+    expect(context.actionInProgress.value).toEqual({ id: StudioItemActionId.UploadMedia })
+
+    /* STEP 2: FILES SELECTED - the action must be released once the upload completes */
+    await context.itemActionHandler[StudioItemActionId.UploadMedia]({
+      parentFsPath: parentPath,
+      files: [createMockFile(mediaName)],
+    })
+    expect(context.actionInProgress.value).toBeNull()
+
+    /* STEP 3: TRIGGER UPLOAD AGAIN - a released action can be triggered again */
+    await uploadAction().handler!({ parentFsPath: parentPath, files: [] })
+    expect(context.actionInProgress.value).toEqual({ id: StudioItemActionId.UploadMedia })
+  })
+
   it('Upload > Rename', async () => {
     const consoleInfoSpy = vi.spyOn(console, 'info')
     const file = createMockFile(mediaName)


### PR DESCRIPTION
### What breaks

Fixes #540

Clicking **Upload media**, then dismissing the OS file picker, permanently disables the button. The picker never reopens until the page is reloaded. The same happens after a successful upload.

### Why

`ItemActionsToolbar` opens the picker indirectly: the button sets `context.actionInProgress`, and a watcher reacts by clicking a hidden `<input type="file">`. Reopening therefore requires that state to go back to `null` first.

`UploadMedia` is in neither `oneStepActions` nor `twoStepActions` (`utils/context.ts:3-4`), so the re-entrancy guard in `useContext.ts:83-95` turns any second dispatch into a bare `return` while the action is still marked in progress. And nothing marks it finished:


**What the fix does:** releases the action at both terminal outcomes, each where the codebase already does that: `unsetActionInProgress()` at the end of the raw handler (matching the two Create handlers), and `@cancel` on the input (mirroring `ItemCardForm`'s dismissal paths).