### PR TITLE
fix(document): ignore explicit #default slot markers when comparing content

### DIFF
--- a/src/module/src/runtime/utils/document/compare.ts
+++ b/src/module/src/runtime/utils/document/compare.ts
@@ -21,6 +21,23 @@ function normalizeAttrsDeep(tree: ComarkTree): ComarkTree {
   return { ...tree, nodes: tree.nodes.map(normalizeNode) }
 }
 
+/**
+ * Unwrap a leading `#default` slot marker, which comark keeps but `@nuxtjs/mdc` erases.
+ */
+function unwrapLeadingDefaultSlot(children: ComarkNode[]): ComarkNode[] {
+  const [first, ...rest] = children
+  if (!Array.isArray(first) || first[0] !== 'template') return children
+
+  // Leading and attribute-free only: elsewhere the marker is load-bearing, and attributes
+  // are content. `$` is comark-internal, ignored by its template handler too.
+  const attrs = (first[1] || {}) as Record<string, unknown>
+  if (attrs.name !== 'default' || Object.keys(attrs).some(key => key !== 'name' && key !== '$')) {
+    return children
+  }
+
+  return [...(first.slice(2) as ComarkNode[]), ...rest]
+}
+
 function normalizeNode(node: ComarkNode): ComarkNode {
   if (typeof node === 'string') return node
   if (!Array.isArray(node)) return node
@@ -32,7 +49,9 @@ function normalizeNode(node: ComarkNode): ComarkNode {
     ? Object.fromEntries(Object.entries(attrs as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b)))
     : attrs
 
-  return [tag, sortedAttrs, ...children.map(normalizeNode)] as ComarkNode
+  const normalizedChildren = unwrapLeadingDefaultSlot(children as ComarkNode[]).map(normalizeNode)
+
+  return [tag, sortedAttrs, ...normalizedChildren] as ComarkNode
 }
 
 export async function isDocumentMatchingContent(content: string, document: DatabaseItem): Promise<boolean> {

--- a/src/module/test/utils/document.test.ts
+++ b/src/module/test/utils/document.test.ts
@@ -414,6 +414,125 @@ Description`
     expect(result).toBe(true)
   })
 
+  it('should be true when the source markdown marks the default slot explicitly', async () => {
+    const markdownContent = `::card{orientation="horizontal"}\n#default\n  :::icon{name="rocket"}\n  :::\n\n#body\nSome text.\n::\n`
+
+    const document = {
+      id: 'docs/test.md',
+      title: '',
+      body: {
+        nodes: [[
+          'card',
+          { orientation: 'horizontal' },
+          ['icon', { name: 'rocket' }],
+          ['template', { name: 'body' }, 'Some text.'],
+        ]],
+        frontmatter: {},
+        meta: {},
+      },
+      description: '',
+      extension: 'md',
+      layout: null,
+      links: null,
+      meta: {},
+      navigation: true,
+      path: '/test',
+      stem: 'test',
+      fsPath: 'test.md',
+    } as unknown as DatabaseItem
+
+    const result = await isDocumentMatchingContent(markdownContent, document)
+    expect(result).toBe(true)
+  })
+
+  it('should be true when a nested block marks the default slot explicitly', async () => {
+    const markdownContent = `::card\n  :::note\n  #default\n  Para one.\n\n  Para two.\n\n  #body\n  Body text.\n  :::\n::\n`
+
+    const document = {
+      id: 'docs/test.md',
+      title: '',
+      body: {
+        nodes: [[
+          'card',
+          {},
+          ['note', {}, ['p', {}, 'Para one.'], ['p', {}, 'Para two.'], ['template', { name: 'body' }, 'Body text.']],
+        ]],
+        frontmatter: {},
+        meta: {},
+      },
+      description: '',
+      extension: 'md',
+      layout: null,
+      links: null,
+      meta: {},
+      navigation: true,
+      path: '/test',
+      stem: 'test',
+      fsPath: 'test.md',
+    } as unknown as DatabaseItem
+
+    const result = await isDocumentMatchingContent(markdownContent, document)
+    expect(result).toBe(true)
+  })
+
+  it('should still be false when a default slot marker follows a named slot', async () => {
+    // Without the marker the trailing content parses into the preceding `#body` slot.
+    const markdownContent = `::card\n#body\nBody text.\n\n#default\nDefault text.\n::\n`
+
+    const document = {
+      id: 'docs/test.md',
+      title: '',
+      body: {
+        nodes: [[
+          'card',
+          {},
+          ['template', { name: 'body' }, ['p', {}, 'Body text.']],
+          ['p', {}, 'Default text.'],
+        ]],
+        frontmatter: {},
+        meta: {},
+      },
+      description: '',
+      extension: 'md',
+      layout: null,
+      links: null,
+      meta: {},
+      navigation: true,
+      path: '/test',
+      stem: 'test',
+      fsPath: 'test.md',
+    } as unknown as DatabaseItem
+
+    const result = await isDocumentMatchingContent(markdownContent, document)
+    expect(result).toBe(false)
+  })
+
+  it('should still be false when the default slot marker carries attributes', async () => {
+    const markdownContent = `::card\n#default{.text-primary}\nHello\n\n#body\nBody text.\n::\n`
+
+    const document = {
+      id: 'docs/test.md',
+      title: '',
+      body: {
+        nodes: [['card', {}, ['p', {}, 'Hello'], ['template', { name: 'body' }, 'Body text.']]],
+        frontmatter: {},
+        meta: {},
+      },
+      description: '',
+      extension: 'md',
+      layout: null,
+      links: null,
+      meta: {},
+      navigation: true,
+      path: '/test',
+      stem: 'test',
+      fsPath: 'test.md',
+    } as unknown as DatabaseItem
+
+    const result = await isDocumentMatchingContent(markdownContent, document)
+    expect(result).toBe(false)
+  })
+
   it('should still be false when content actually differs', async () => {
     const markdownContent = `::card{orientation="horizontal"}\nHello\n::\n`
 


### PR DESCRIPTION
A page whose markdown carries an explicit `#default` marker is reported as conflicted forever, and the banner blocks the editor before the user can save the normalization that would resolve it. The advice it shows ("ensure your latest changes are deployed and refresh") cannot help — nothing is stale.

`@nuxtjs/mdc` parses such a file to a byte-identical AST with and without the marker, so the stored body never records it, while comark keeps it when parsing from Git. Only blocks with a sibling slot are affected: comark omits the marker when the default slot is the only one.

Two things I noticed but left alone:

- Single-line default-slot content still mismatches. comark parses `#default` plus one text line to a bare string, but the marker-less form wraps it in a `p`, so unwrapping alone doesn't equalize the trees. The asymmetry is on comark's parse side, so fixing it here felt wrong.
- comark drops `#default`'s attributes when it is the only slot — the `templateCount === 1` early return skips `comarkAttributes`.

`areDocumentsEqual` compares two stored documents, so both sides come from the same parser; I left it without this normalization.
