### PR TITLE
feat(editor): add configurable TipTap slash menu item limit

### DIFF
--- a/src/app/src/components/content/editor/ContentEditorTipTap.vue
+++ b/src/app/src/components/content/editor/ContentEditorTipTap.vue
@@ -229,6 +229,7 @@ watch(() => `${document.value?.id}-${props.draftItem.version}-${props.draftItem.
       <UEditorSuggestionMenu
         :editor="editor"
         :items="suggestionItems"
+        :limit="host.meta.editor.suggestion.limit"
       />
 
       <UEditorEmojiMenu

--- a/src/app/src/shared.ts
+++ b/src/app/src/shared.ts
@@ -1,6 +1,6 @@
 export type { MarkdownParsingOptions } from './types/content'
 export type { GitProviderType } from './types/git'
-export type { ComponentMeta, CommandKey, CommandConfig } from './types/editor'
+export type { ComponentMeta, CommandKey, CommandConfig, SuggestionConfig } from './types/editor'
 export type { AIGenerateOptions, AIHintOptions, CursorContext, DiffPart, AITransformCallbacks } from './types/ai'
 
 // Temporary export for remark emoji plugin

--- a/src/app/src/types/editor.ts
+++ b/src/app/src/types/editor.ts
@@ -62,3 +62,11 @@ export type CommandKey = typeof COMMAND_KEYS[number]
 export interface CommandConfig {
   exclude?: CommandKey[]
 }
+
+export interface SuggestionConfig {
+  /**
+   * Maximum number of items shown in the TipTap slash menu without a search query.
+   * @default 200
+   */
+  limit?: number
+}

--- a/src/app/src/types/index.ts
+++ b/src/app/src/types/index.ts
@@ -4,7 +4,7 @@ import type { DatabaseItem } from './database'
 import type { RouteLocationNormalized } from 'vue-router'
 import type { MediaItem, MediaConfig } from './media'
 import type { Repository } from './git'
-import type { ComponentMeta, CommandConfig } from './editor'
+import type { ComponentMeta, CommandConfig, SuggestionConfig } from './editor'
 import type { MarkdownParsingOptions, SyntaxHighlightTheme } from './content'
 import type { CollectionInfo } from '@nuxt/content'
 
@@ -48,6 +48,7 @@ export interface StudioHost {
         getGroups: (fallbackLabel: string) => Array<{ label: string, components: ComponentMeta[] }>
       }
       commands: CommandConfig
+      suggestion: SuggestionConfig
       iconLibraries?: string[]
       highlightTheme: SyntaxHighlightTheme
       markdown?: { contentHeading?: boolean }

--- a/src/module/src/module.ts
+++ b/src/module/src/module.ts
@@ -7,7 +7,7 @@ import { setupDevMode } from './dev'
 import { validateAuthConfig } from './auth'
 import { setExternalMediaStorage, setDefaultMediaStorage } from './medias'
 import { setAIFeature } from './ai'
-import type { CommandConfig } from '../../app/src/types/editor'
+import type { CommandConfig, SuggestionConfig } from '../../app/src/types/editor'
 
 const logger = useLogger('nuxt-studio')
 
@@ -60,6 +60,10 @@ interface EditorOptions {
    * @example ['material-symbols', 'lucide']
    */
   iconLibraries?: string[]
+  /**
+   * TipTap slash menu suggestion settings.
+   */
+  suggestion?: SuggestionConfig
 }
 
 interface MediaUploadOptions {
@@ -447,6 +451,9 @@ export default defineNuxtModule<ModuleOptions>({
         groups: undefined,
         ungrouped: 'include',
       },
+      suggestion: {
+        limit: 200,
+      },
     },
     media: {
       external: false,
@@ -546,6 +553,7 @@ export default defineNuxtModule<ModuleOptions>({
       git: { commit: { messagePrefix: options.git?.commit?.messagePrefix ?? '' } },
       iconLibraries: editorOptions?.iconLibraries,
       commands: { exclude: [], ...editorOptions?.commands },
+      suggestion: { limit: 200, ...editorOptions?.suggestion },
     }
 
     // Studio runtime config

--- a/src/module/src/runtime/host.ts
+++ b/src/module/src/runtime/host.ts
@@ -103,6 +103,7 @@ export function useStudioHost(user: StudioUser, repository: Repository): StudioH
           },
         },
         commands: studioConfig.commands ?? { exclude: [] },
+        suggestion: studioConfig.suggestion ?? { limit: 200 },
         iconLibraries: studioConfig.iconLibraries,
         get highlightTheme() { return meta.highlightTheme.value! },
         get markdown() { return meta.markdownConfig.value },


### PR DESCRIPTION
## Summary

- Adds `studio.editor.suggestion.limit` to control how many items the TipTap `/` menu shows without a search query
- Raises the default from 42 (Nuxt UI default) to 200 so large component lists are not truncated before later groups

## Usage

```ts
export default defineNuxtConfig({
  studio: {
    editor: {
      suggestion: {
        limit: 300,
      },
    },
  },
})
```

## Test plan

- [ ] Open a markdown file with many components grouped in `studio.editor.components.groups`
- [ ] Trigger the `/` menu with no filter — all groups should be visible (up to the configured limit)
- [ ] Set `limit: 42` to confirm the previous truncation behavior can be restored