### PR TITLE
fix(document): skip no-op YAML rewrites on editor open

### DIFF
--- a/src/app/src/components/content/editor/ContentEditorTipTap.vue
+++ b/src/app/src/components/content/editor/ContentEditorTipTap.vue
@@ -3,7 +3,7 @@ import type { PropType } from 'vue'
 import type { JSONContent } from '@tiptap/vue-3'
 import type { ComarkTree } from 'comark'
 import type { DraftItem, DatabasePageItem } from '../../../types'
-import { ref, watch, computed } from 'vue'
+import { ref, watch, computed, nextTick } from 'vue'
 import { useStudio } from '../../../composables/useStudio'
 import { useStudioState } from '../../../composables/useStudioState'
 import { comarkToTiptap } from '../../../utils/tiptap/comarkToTiptap'
@@ -84,11 +84,12 @@ const currentComark = ref<ComarkTree>()
 const currentContent = ref<string>()
 
 let isConverting = false
+let isApplyingDocumentToEditor = false
 
 // TipTap to Markdown
 watch(tiptapJSON, async (json) => {
-  // Skip if already converting (prevents UEditor v-model from triggering multiple times)
-  if (isConverting) {
+  // Skip updates emitted while hydrating TipTap from the stored document.
+  if (isConverting || isApplyingDocumentToEditor) {
     return
   }
 
@@ -126,7 +127,10 @@ watch(() => `${document.value?.id}-${props.draftItem.version}-${props.draftItem.
   const newTiptapJSON = comarkToTiptap(comarkTree, { hasNuxtUI: hasNuxtUI.value })
 
   if (!tiptapJSON.value || JSON.stringify(newTiptapJSON) !== JSON.stringify(removeLastEmptyParagraph(tiptapJSON.value))) {
+    isApplyingDocumentToEditor = true
     tiptapJSON.value = newTiptapJSON
+    await nextTick()
+    isApplyingDocumentToEditor = false
 
     if (debug.value && !currentComark.value) {
       const generatedContent = await host.document.generate.contentFromDocument(document.value!) || ''

--- a/src/app/src/components/tiptap/TiptapComponentProps.vue
+++ b/src/app/src/components/tiptap/TiptapComponentProps.vue
@@ -3,9 +3,8 @@ import { ref, computed, unref, onMounted } from 'vue'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import type { PropType } from 'vue'
 import { pascalCase, titleCase, kebabCase, flatCase } from 'scule'
-import { buildFormTreeFromProps } from '../../utils/tiptap/props'
+import { buildFormTreeFromProps, convertFormTreeToProps } from '../../utils/tiptap/props'
 import { useStudio } from '../../composables/useStudio'
-import { isEmpty } from '../../utils/object'
 import type { ComponentMeta, FormTree } from '../../types'
 
 const props = defineProps({
@@ -65,33 +64,6 @@ const formTreeWithValues = computed(() => {
   }
 })
 
-// Convert form tree to props object for saving
-function convertTreeToPropsObject(tree: FormTree): Record<string, unknown> {
-  const result: Record<string, unknown> = {}
-
-  for (const key of Object.keys(tree)) {
-    const prop = tree[key]
-
-    // Handle special case for rel attribute
-    let value = prop.value
-    if (prop.key === 'rel' && value === 'Default value applied') {
-      value = 'nofollow,noopener,noreferrer'
-    }
-
-    // Only include non-empty values
-    if (['boolean', 'number'].includes(typeof value) || !isEmpty(value as Record<string, unknown>)) {
-      result[prop.key!] = typeof value === 'string' ? value : JSON.stringify(value)
-    }
-
-    // Remove if value equals default
-    if (prop.default === value && prop.key) {
-      Reflect.deleteProperty(result, prop.key)
-    }
-  }
-
-  return result
-}
-
 // Update a prop value (supports nested paths for objects)
 function updateFormTree(updatedTree: FormTree) {
   // Find what changed by comparing trees
@@ -114,7 +86,7 @@ function updateFormTree(updatedTree: FormTree) {
   }
 
   // Update props in editor
-  props.updateProps(convertTreeToPropsObject(formTree.value))
+  props.updateProps(convertFormTreeToProps(formTree.value, props.node.attrs.props))
 }
 
 function updatePropValue(key: string, updatedProp: FormTree[string], originalProp: FormTree[string]) {

--- a/src/app/src/utils/tiptap/props.ts
+++ b/src/app/src/utils/tiptap/props.ts
@@ -6,6 +6,7 @@ import type { FormItem, FormTree } from '../../types'
 import type { ComponentMeta } from '../../types/editor'
 import type { PropertyMeta, PropertyMetaSchema } from 'vue-component-meta'
 import type { ComarkElementAttributes } from 'comark'
+import { isEmpty } from '../object'
 
 const HIDDEN_PROPS = [
   'ui',
@@ -157,6 +158,49 @@ export function normalizeProps(nodeProps: Record<string, unknown>, extraProps: o
 
 export const stripBindingPrefix = (key: string): string => (key.startsWith(':') ? key.slice(1) : key)
 
+/**
+ * Convert component form values back to TipTap props while retaining the
+ * insertion order of props already present on the source node.
+ *
+ * @param formTree - Component form fields and their current values.
+ * @param sourceProps - Props from the TipTap node before the form update.
+ * @returns Props ready to pass to TipTap's `updateAttributes`.
+ */
+export function convertFormTreeToProps(formTree: FormTree, sourceProps: Record<string, unknown> = {}): Record<string, unknown> {
+  const formItems = Object.values(formTree)
+  const sourceItems = Object.keys(sourceProps).flatMap((sourceKey) => {
+    const normalizedSourceKey = kebabCase(stripBindingPrefix(sourceKey))
+    const item = formItems.find(item => item.key && kebabCase(stripBindingPrefix(item.key)) === normalizedSourceKey)
+
+    return item ? [item] : []
+  })
+  const sourceItemKeys = new Set(sourceItems.map(item => item.key))
+  const orderedItems = [
+    ...sourceItems,
+    ...formItems.filter(item => !sourceItemKeys.has(item.key)),
+  ]
+  const result: Record<string, unknown> = {}
+
+  for (const item of orderedItems) {
+    if (!item.key) continue
+
+    let value = item.value
+    if (item.key === 'rel' && value === 'Default value applied') {
+      value = 'nofollow,noopener,noreferrer'
+    }
+
+    if (['boolean', 'number'].includes(typeof value) || !isEmpty(value as Record<string, unknown>)) {
+      result[item.key] = typeof value === 'string' ? value : JSON.stringify(value)
+    }
+
+    if (item.default === value && !sourceItemKeys.has(item.key)) {
+      Reflect.deleteProperty(result, item.key)
+    }
+  }
+
+  return result
+}
+
 // Stored attrs may be kebab-cased while meta declares props in camelCase (e.g. `foo-bar` vs `fooBar`)
 const resolveNodePropValue = (nodeProps: Record<string, unknown>, key: string): unknown => {
   if (key in nodeProps) return nodeProps[key]
@@ -261,7 +305,8 @@ export const buildFormTreeFromProps = (node: ProseMirrorNode, componentMeta: Com
 const buildPropItem = (componentId: string, prop: PropertyMeta, nodeProps: Record<string, unknown>, level = 0, parent?: FormItem): FormItem => {
   const key = prop.name
   const title = upperFirst(prop.name)
-  const defaultValue: string | boolean | number | object | unknown[] | null = prop.tags?.find(tag => tag.name === 'defaultValue')?.text || ''
+  const defaultValue: string | boolean | number | object | unknown[] | null
+    = prop.tags?.find(tag => tag.name === 'defaultValue')?.text ?? prop.default ?? ''
 
   const { type, options } = computeTypeAndOptions(componentId, key, prop, level)
 

--- a/src/app/test/unit/utils/tiptap/props.test.ts
+++ b/src/app/test/unit/utils/tiptap/props.test.ts
@@ -2,7 +2,7 @@ import { expect, test, describe } from 'vitest'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import type { JSType } from 'untyped'
 import type { PropertyMeta } from 'vue-component-meta'
-import { buildAttrs, buildFormTreeFromProps, convertStringToArray, convertStringToValue, normalizeProps } from '../../../../src/utils/tiptap/props'
+import { buildAttrs, buildFormTreeFromProps, convertFormTreeToProps, convertStringToArray, convertStringToValue, normalizeProps } from '../../../../src/utils/tiptap/props'
 import { buttonPropsSchema, iconPropsSchema } from '../../../mocks/props'
 import type { ComponentMeta } from '../../../../src/types/component'
 
@@ -1333,6 +1333,59 @@ describe('props', () => {
       expect(formTree.fooBar).toMatchObject({ key: 'fooBar', value: 'foo bar value', custom: false })
       expect(formTree.bazQux).toMatchObject({ key: 'bazQux', value: 'baz qux value', custom: false })
       expect(formTree.quuxCorge).toMatchObject({ key: 'quuxCorge', value: 'quux corge value', custom: false })
+    })
+
+    test('preserves stored prop order and omits defaults declared by component meta', () => {
+      const props = [
+        { name: 'variant', type: 'string', schema: 'string', tags: [] },
+        { name: 'width', type: 'string', schema: 'string', tags: [] },
+        {
+          name: 'image',
+          type: 'MediaImage',
+          tags: [],
+          schema: {
+            kind: 'object',
+            type: 'MediaImage',
+            schema: {
+              src: { name: 'src', type: 'string', schema: 'string', tags: [] },
+              alt: { name: 'alt', type: 'string', schema: 'string', tags: [] },
+            },
+          },
+        },
+        { name: 'imagePosition', type: 'string', schema: 'string', tags: [] },
+        { name: 'imageSize', type: 'string', schema: 'string', tags: [], default: '"1/2"' },
+      ] as unknown as PropertyMeta[]
+      const sourceProps = {
+        image: { src: '/cat.png', alt: 'A cat' },
+        imagePosition: 'right',
+        variant: 'neutral',
+        width: 'wide',
+      }
+      const node = {
+        type: { name: 'element' },
+        attrs: {
+          tag: 'MediaSection',
+          props: sourceProps,
+        },
+      } as unknown as ProseMirrorNode
+
+      const formTree = buildFormTreeFromProps(node, createComponentMeta(props))
+      const convertedProps = convertFormTreeToProps(formTree, sourceProps)
+
+      expect(Object.keys(convertedProps)).toEqual([':image', 'imagePosition', 'variant', 'width'])
+      expect(convertedProps).not.toHaveProperty('imageSize')
+      expect(formTree.imageSize).toMatchObject({ value: '1/2', default: '1/2' })
+
+      const scalarFirstProps = convertFormTreeToProps(formTree, {
+        variant: 'neutral',
+        width: 'wide',
+        image: sourceProps.image,
+        imagePosition: 'right',
+      })
+      const explicitlyAuthoredDefault = convertFormTreeToProps(formTree, { ...sourceProps, imageSize: '1/2' })
+
+      expect(Object.keys(scalarFirstProps)).toEqual(['variant', 'width', ':image', 'imagePosition'])
+      expect(explicitlyAuthoredDefault).toHaveProperty('imageSize', '1/2')
     })
 
     // test('generate props for video component', () => {

--- a/src/module/src/runtime/host.dev.ts
+++ b/src/module/src/runtime/host.dev.ts
@@ -36,8 +36,18 @@ export function useStudioHost(user: StudioUser, repository: Repository) {
     const id = generateIdFromFsPath(fsPath, collectionInfo)
     const document = applyCollectionSchema(id, collectionInfo, upsertedDocument)
     const sanitizedDocument = sanitizeDocumentTree(document, collectionInfo)
-
     const content = await host.document.generate.contentFromDocument(sanitizedDocument)
+    const currentContent = await devStorage.getItem<string>(fsPath)
+    const renderedDocument = content === null
+      ? null
+      : await host.document.generate.documentFromContent(id, content)
+    const isDocumentUnchanged = typeof currentContent === 'string' && renderedDocument
+      ? await host.document.utils.isMatchingContent(currentContent, renderedDocument)
+      : false
+
+    if (isDocumentUnchanged) {
+      return
+    }
 
     await $fetch('/__nuxt_studio/dev/content/' + fsPath, {
       method: 'PUT',

--- a/src/module/test/utils/document.test.ts
+++ b/src/module/test/utils/document.test.ts
@@ -414,6 +414,53 @@ Description`
     expect(result).toBe(true)
   })
 
+  it('should be true when nested object attributes are reordered by the legacy MDC parser', async () => {
+    const markdownContent = `::media-section
+---
+variant: neutral
+width: wide
+image:
+  src: /cat.png
+  alt: A cat
+imagePosition: right
+---
+#body
+Hello
+::
+`
+
+    const document = {
+      id: 'pages/index.md',
+      title: '',
+      body: {
+        type: 'minimark',
+        value: [[
+          'media-section',
+          {
+            ':image': '{"src":"/cat.png","alt":"A cat"}',
+            'imagePosition': 'right',
+            'variant': 'neutral',
+            'width': 'wide',
+          },
+          ['template', { 'v-slot:body': '' }, ['p', {}, 'Hello']],
+        ]],
+      },
+      description: '',
+      extension: 'md',
+      layout: null,
+      links: null,
+      meta: {},
+      navigation: true,
+      path: '/',
+      stem: 'index',
+      fsPath: 'index.md',
+    } as unknown as DatabaseItem
+
+    const result = await isDocumentMatchingContent(markdownContent, document)
+
+    expect(result).toBe(true)
+  })
+
   it('should be true when the source markdown marks the default slot explicitly', async () => {
     const markdownContent = `::card{orientation="horizontal"}\n#default\n  :::icon{name="rocket"}\n  :::\n\n#body\nSome text.\n::\n`
 


### PR DESCRIPTION
## Summary

Fixes #546.

Opening a page in the visual editor was enough to rewrite `::component` YAML (key order + omitted Vue defaults) and, on the next open, surface a Git vs Website conflict. This PR stops those silent writes and keeps authored prop order when the component form saves.

- Skip TipTap hydration `onUpdate` so mounting the stored document does not write a draft
- Skip the dev-host filesystem PUT when `isMatchingContent` says the rendered document matches the file on disk
- Convert component form values back to props in source key order, omit meta-only Vue defaults, and keep defaults that were already authored
- Cover the #546 `::media-section` YAML-order case in `isDocumentMatchingContent`, plus form-prop round-trip tests

Related: #356, #382, #544.

## Out of scope

- `checkConflict` still has a raw-string fallback after structural compare
- `legacy.ts` unbind order and `getOrderedSchemaKeys` alphabetical frontmatter sort are unchanged

## Test plan

- [ ] Open a page with mixed scalar + nested object YAML (see `content/index.md` in [studio-repro](https://github.com/TotomInc/studio-repro)) without editing — `git status` stays clean
- [ ] Confirm omitted Vue defaults (e.g. `imageSize: 1/2`) are not written into the YAML
- [ ] Confirm an explicitly authored default is kept
- [ ] Re-open the same page in production and confirm no Git vs Website conflict from key-order-only drift
- [ ] Edit a real prop and confirm the file still updates