### PR TITLE
feat(editor): add relation input to reference another collection

### DIFF
--- a/docs/content/5.content.md
+++ b/docs/content/5.content.md
@@ -270,17 +270,66 @@ image: property(z.string()).editor({ input: 'media' })
 
 // Textarea
 description: property(z.string()).editor({ input: 'textarea' })
+
+// Reference a document of another collection
+author: property(z.string()).editor({
+  input: 'relation',
+  relation: { collection: 'authors', labelField: 'name' },
+})
 ```
 
 #### Options
 
-##### `input: 'media' | 'icon' | 'textarea'`
+##### `input: 'media' | 'icon' | 'textarea' | 'relation'`
 
-You can set the editor input type. Currently `icon`, `media` and `textarea` are available.
+You can set the editor input type. Currently `icon`, `media`, `textarea` and `relation` are available.
 
 - `icon` - Opens an icon picker with searchable Iconify libraries
 - `media` - Opens the media picker to select images from your library
 - `textarea` - Renders a multi-line text input instead of a single-line text field
+- `relation` - Opens a searchable picker listing the documents of another collection
+
+##### `relation: { collection, valueField?, labelField? }`
+
+Declares that a string field references a document of another collection, so
+editors pick from a searchable list instead of typing an identifier by hand.
+
+```ts [content.config.ts]
+export default defineContentConfig({
+  collections: {
+    authors: defineCollection({
+      type: 'data',
+      source: 'authors/**',
+      schema: z.object({
+        name: z.string(),
+      }),
+    }),
+    posts: defineCollection({
+      type: 'page',
+      source: 'posts/**',
+      schema: z.object({
+        author: property(z.string()).editor({
+          input: 'relation',
+          relation: { collection: 'authors', labelField: 'name' },
+        }),
+      }),
+    }),
+  },
+})
+```
+
+- `collection` - Name of the referenced collection, as declared in `content.config.ts`. Both `page` and `data` collections are supported.
+- `valueField` - Field written to the file. Defaults to `slug`, the document file name, which is what a document is usually referenced by. `path` (route) and `stem` (source relative path) are also available, as is any field of the referenced document.
+- `labelField` - Field displayed in the picker. Defaults to `name`, then `title`, then the stored value.
+
+The field keeps storing a plain string, so content queries and existing
+documents are unaffected — and the value stays editable by hand. A value that
+matches no document is flagged in the editor but never rewritten.
+
+::note
+References are not validated at build time: the picker prevents typos, it does
+not guarantee that a value still resolves after a document is renamed.
+::
 
 ##### `label: string`
 

--- a/playground/docus/content.config.ts
+++ b/playground/docus/content.config.ts
@@ -1,9 +1,16 @@
-import type { DefinedCollection } from '@nuxt/content'
+import type { DefinedCollection, EditorOptions } from '@nuxt/content'
 import { defineContentConfig, defineCollection, property } from '@nuxt/content'
 import z from 'zod/v3'
 
 const createDocsSchema = () => z.object({
   layout: z.string().optional(),
+  // Cast until `relation` lands in `EditorOptions` upstream in @nuxt/content
+  author: property(z.string()).editor({
+    input: 'relation',
+    relation: { collection: 'authors', labelField: 'name' },
+    label: 'Author',
+    description: 'Author of the page, picked from the authors collection',
+  } as EditorOptions),
   links: z.array(z.object({
     label: z.string(),
     icon: z.string(),

--- a/src/app/src/components/form/FormInput.vue
+++ b/src/app/src/components/form/FormInput.vue
@@ -43,6 +43,7 @@ function computeValue(formItem: FormItem): unknown {
     case 'media':
     case 'file':
     case 'textarea':
+    case 'relation':
       return typeof value === 'string' ? value : ''
     case 'boolean':
       return typeof value === 'boolean' ? value : false

--- a/src/app/src/components/form/input/InputRelation.vue
+++ b/src/app/src/components/form/input/InputRelation.vue
@@ -1,0 +1,186 @@
+<script setup lang="ts">
+import type { FormItem } from '../../../types'
+import type { RelationOption } from '../../../utils/relation'
+import type { PropType } from 'vue'
+import { ref, computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useStudio } from '../../../composables/useStudio'
+import { buildRelationOptions, filterRelationOptions } from '../../../utils/relation'
+
+const props = defineProps({
+  formItem: {
+    type: Object as PropType<FormItem>,
+    default: () => ({}),
+  },
+})
+
+const model = defineModel<string>({ default: '' })
+
+const { host } = useStudio()
+const { t } = useI18n()
+
+const popoverOpen = ref(false)
+const search = ref('')
+const isLoading = ref(true)
+const options = ref<RelationOption[]>([])
+
+const relation = computed(() => props.formItem?.relation)
+
+// Documents of the referenced collection, as { value, label } picker options
+async function loadOptions() {
+  const target = relation.value
+  if (!target?.collection) {
+    options.value = []
+    isLoading.value = false
+    return
+  }
+
+  isLoading.value = true
+  try {
+    const documents = await host.document.db.list()
+    const items = documents.filter(document =>
+      document.fsPath && host.collection.getByFsPath(document.fsPath)?.name === target.collection,
+    )
+
+    options.value = buildRelationOptions(items, target)
+  }
+  catch {
+    options.value = []
+  }
+  finally {
+    isLoading.value = false
+  }
+}
+
+watch(() => relation.value?.collection, loadOptions, { immediate: true })
+
+const filteredOptions = computed(() => filterRelationOptions(options.value, search.value))
+
+// Label of the stored value, so the field reads as a name instead of a slug
+const selectedLabel = computed(() => options.value.find(option => option.value === model.value)?.label)
+
+// A value matching no document is left untouched but flagged, never rewritten
+const isUnresolved = computed(() => Boolean(model.value) && !isLoading.value && !selectedLabel.value)
+
+const tooltip = computed(() => {
+  if (isUnresolved.value) {
+    return t('studio.form.relation.unresolved')
+  }
+
+  return selectedLabel.value || t('studio.form.relation.collectionHint', { collection: relation.value?.collection })
+})
+
+function selectOption(option: RelationOption) {
+  model.value = option.value
+  popoverOpen.value = false
+  search.value = ''
+}
+</script>
+
+<template>
+  <div class="flex items-center gap-1">
+    <UTooltip
+      v-if="relation?.collection"
+      :text="tooltip"
+    >
+      <div class="flex items-center justify-center size-6 bg-muted border border-muted rounded shrink-0">
+        <UIcon
+          v-if="isUnresolved"
+          name="i-lucide-triangle-alert"
+          class="text-warning"
+        />
+        <UIcon
+          v-else-if="selectedLabel"
+          name="i-lucide-link"
+          class="text-muted"
+        />
+        <UIcon
+          v-else
+          name="i-lucide-link-2-off"
+          class="text-dimmed"
+        />
+      </div>
+    </UTooltip>
+
+    <UInput
+      v-model="model"
+      :placeholder="$t('studio.form.relation.placeholder')"
+      size="xs"
+      class="flex-1"
+    >
+      <template
+        v-if="relation?.collection"
+        #trailing
+      >
+        <UPopover
+          v-model:open="popoverOpen"
+          :portal="false"
+          :content="{ side: 'left' }"
+          :ui="{ content: 'z-[1000]' }"
+        >
+          <UButton
+            size="xs"
+            color="neutral"
+            variant="none"
+            icon="i-lucide-search"
+            class="cursor-pointer"
+          />
+
+          <template #content>
+            <div class="p-3 w-72">
+              <UInput
+                v-model="search"
+                :placeholder="$t('studio.form.relation.searchPlaceholder')"
+                size="xs"
+                icon="i-lucide-search"
+                autofocus
+                class="mb-3 w-full"
+              />
+
+              <div
+                v-if="isLoading"
+                class="flex items-center justify-center py-4"
+              >
+                <UIcon
+                  name="i-lucide-loader-2"
+                  class="size-5 animate-spin text-muted"
+                />
+              </div>
+
+              <div
+                v-else-if="filteredOptions.length > 0"
+                class="flex flex-col gap-0.5 max-h-48 overflow-y-auto"
+              >
+                <button
+                  v-for="option in filteredOptions"
+                  :key="option.value"
+                  type="button"
+                  class="flex flex-col items-start text-left px-2 py-1 rounded cursor-pointer hover:bg-elevated"
+                  :class="{ 'bg-elevated': option.value === model }"
+                  @click="selectOption(option)"
+                >
+                  <span class="text-xs text-highlighted truncate max-w-full">{{ option.label }}</span>
+                  <span class="text-[10px] text-dimmed font-mono truncate max-w-full">{{ option.value }}</span>
+                </button>
+              </div>
+
+              <p
+                v-else
+                class="text-xs text-muted text-center py-4"
+              >
+                {{ search ? $t('studio.form.relation.noResultsFound') : $t('studio.form.relation.noDocumentsAvailable', { collection: relation.collection }) }}
+              </p>
+
+              <p
+                v-if="!isLoading && filteredOptions.length > 0"
+                class="text-xs text-dimmed mt-2"
+              >
+                {{ $t('studio.form.relation.optionCount', { count: filteredOptions.length, total: options.length }, options.length) }}
+              </p>
+            </div>
+          </template>
+        </UPopover>
+      </template>
+    </UInput>
+  </div>
+</template>

--- a/src/app/src/components/form/input/InputWrapper.vue
+++ b/src/app/src/components/form/input/InputWrapper.vue
@@ -12,6 +12,7 @@ import InputText from './InputText.vue'
 import InputObject from './InputObject.vue'
 import InputArray from './InputArray.vue'
 import InputTextarea from './InputTextarea.vue'
+import InputRelation from './InputRelation.vue'
 
 const typeComponentMap: Partial<Record<FormInputsTypes, Component>> = {
   array: InputArray,
@@ -24,6 +25,7 @@ const typeComponentMap: Partial<Record<FormInputsTypes, Component>> = {
   string: InputText,
   object: InputObject,
   textarea: InputTextarea,
+  relation: InputRelation,
 }
 
 const props = defineProps({

--- a/src/app/src/locales/en.json
+++ b/src/app/src/locales/en.json
@@ -398,6 +398,15 @@
         "libraries": "Libraries:",
         "allLibraries": "All"
       },
+      "relation": {
+        "placeholder": "Enter a slug...",
+        "searchPlaceholder": "Search documents...",
+        "noResultsFound": "No documents found",
+        "noDocumentsAvailable": "No documents in {collection}",
+        "unresolved": "No document matches this value",
+        "collectionHint": "References {collection}",
+        "optionCount": "{count} of {total} document | {count} of {total} documents"
+      },
       "text": {
         "placeholder": "Enter text...",
         "selectPlaceholder": "Select an option..."

--- a/src/app/src/types/editor.ts
+++ b/src/app/src/types/editor.ts
@@ -12,7 +12,30 @@ export interface ComponentMeta {
   }
 }
 
-export type FormInputsTypes = JSType | 'icon' | 'media' | 'file' | 'date' | 'datetime' | 'textarea'
+export type FormInputsTypes = JSType | 'icon' | 'media' | 'file' | 'date' | 'datetime' | 'textarea' | 'relation'
+
+/**
+ * Describes a reference from a string field to a document of another collection.
+ * The field keeps storing a plain string, so files stay valid for any consumer.
+ */
+export interface RelationOptions {
+  /**
+   * Name of the referenced collection, as declared in `content.config.ts`.
+   */
+  collection: string
+  /**
+   * Field of the referenced document written to the file.
+   * `slug` (default) uses the document file name, `path` its route and `stem`
+   * its source relative path. Any other value is read from the document itself.
+   * @default 'slug'
+   */
+  valueField?: 'slug' | 'path' | 'stem' | (string & {})
+  /**
+   * Field of the referenced document displayed in the picker.
+   * Defaults to `name`, then `title`, then the stored value.
+   */
+  labelField?: string
+}
 
 export type FormTree = Record<string, FormItem>
 export type FormItem = {
@@ -22,6 +45,7 @@ export type FormItem = {
   value?: unknown
   default?: unknown
   options?: string[]
+  relation?: RelationOptions
   title: string
   icon?: string
   children?: FormTree

--- a/src/app/src/utils/form.ts
+++ b/src/app/src/utils/form.ts
@@ -1,7 +1,17 @@
 import type { Draft07, Draft07DefinitionProperty, Draft07DefinitionPropertyAnyOf, Draft07DefinitionPropertyAllOf, Draft07DefinitionPropertyOneOf, EditorOptions } from '@nuxt/content'
-import type { FormTree, FormItem } from '../types'
+import type { FormTree, FormItem, FormInputsTypes, RelationOptions } from '../types'
 import { upperFirst, titleCase } from 'scule'
 import { omit } from './object'
+
+/**
+ * `EditorOptions` in `@nuxt/content` only lists the inputs it shipped with, while
+ * `.editor()` forwards its whole argument to the generated schema. Studio reads
+ * the inputs it implements plus their own options from there.
+ */
+type StudioEditorOptions = Omit<EditorOptions, 'input'> & {
+  input?: FormInputsTypes
+  relation?: RelationOptions
+}
 
 export function formItemInputLabel(formItem: FormItem): string {
   const custom = formItem.label?.trim()
@@ -18,7 +28,7 @@ export function formItemInputLabel(formItem: FormItem): string {
 function editorDisplayFromContent(
   content: Draft07DefinitionProperty['$content'],
 ): Partial<Pick<FormItem, 'label' | 'description' | 'tooltip'>> {
-  const editor = content?.editor as EditorOptions | undefined
+  const editor = content?.editor as StudioEditorOptions | undefined
   if (!editor) {
     return {}
   }
@@ -48,7 +58,7 @@ export const buildFormTreeFromSchema = (treeKey: string, schema: Draft07): FormT
     const itemKey = paths.pop()!.replace('#', '')
     const level = paths.length
 
-    const editor = def.$content?.editor
+    const editor = def.$content?.editor as StudioEditorOptions | undefined
     if (editor?.hidden) {
       return null
     }
@@ -154,6 +164,11 @@ export const buildFormTreeFromSchema = (treeKey: string, schema: Draft07): FormT
         item.options = editor.iconLibraries
       }
 
+      // Pass relation options from editor options for relation inputs
+      if (editor?.relation?.collection) {
+        item.relation = editor.relation
+      }
+
       return item
     }
 
@@ -178,6 +193,11 @@ export const buildFormTreeFromSchema = (treeKey: string, schema: Draft07): FormT
     // Pass iconLibraries from editor options for icon inputs
     else if (editor?.iconLibraries && Array.isArray(editor.iconLibraries)) {
       item.options = editor.iconLibraries as string[]
+    }
+
+    // Pass relation options from editor options for relation inputs
+    if (editor?.relation?.collection) {
+      item.relation = editor.relation
     }
 
     return item

--- a/src/app/src/utils/relation.ts
+++ b/src/app/src/utils/relation.ts
@@ -1,0 +1,93 @@
+import type { DatabaseItem, RelationOptions } from '../types'
+
+export interface RelationOption {
+  /** Value written to the file. */
+  value: string
+  /** Human readable label displayed in the picker. */
+  label: string
+}
+
+// Fields used as a label when the relation does not name one
+const DEFAULT_LABEL_FIELDS = ['name', 'title']
+
+/**
+ * File name of a document, without its extension.
+ *
+ * Nuxt Content sources identify a document inside its collection by its file
+ * name, which is the slug cross-collection references are written with.
+ */
+export function relationSlug(item: DatabaseItem): string {
+  return String(item.stem || '').split('/').pop() || ''
+}
+
+/**
+ * Value of the field a relation references on a document.
+ *
+ * `slug` is not a Nuxt Content field, so it falls back to the document file
+ * name when the document does not define one itself.
+ */
+export function relationValue(item: DatabaseItem, valueField: string = 'slug'): string {
+  const value = item[valueField]
+
+  if (typeof value === 'string' && value) {
+    return value
+  }
+  if (typeof value === 'number') {
+    return String(value)
+  }
+
+  return valueField === 'slug' ? relationSlug(item) : ''
+}
+
+/**
+ * Label of a document in the picker: the field the relation names, then the
+ * usual title fields, then the value itself so a row is never blank.
+ */
+export function relationLabel(item: DatabaseItem, value: string, labelField?: string): string {
+  const fields = labelField ? [labelField, ...DEFAULT_LABEL_FIELDS] : DEFAULT_LABEL_FIELDS
+
+  for (const field of fields) {
+    const label = item[field]
+    if (typeof label === 'string' && label.trim()) {
+      return label
+    }
+  }
+
+  return value
+}
+
+/**
+ * Turns the documents of a referenced collection into picker options, dropping
+ * the ones with no referenceable value and sorting them by label.
+ */
+export function buildRelationOptions(items: DatabaseItem[], relation: RelationOptions): RelationOption[] {
+  const options: RelationOption[] = []
+  const seen = new Set<string>()
+
+  for (const item of items) {
+    const value = relationValue(item, relation.valueField)
+    if (!value || seen.has(value)) {
+      continue
+    }
+
+    seen.add(value)
+    options.push({ value, label: relationLabel(item, value, relation.labelField) })
+  }
+
+  return options.sort((a, b) => a.label.localeCompare(b.label))
+}
+
+/**
+ * Filters picker options on both the label and the stored value, so editors can
+ * search by display name or by the slug they already know.
+ */
+export function filterRelationOptions(options: RelationOption[], search: string): RelationOption[] {
+  const query = search.trim().toLowerCase()
+  if (!query) {
+    return options
+  }
+
+  return options.filter(option =>
+    option.label.toLowerCase().includes(query) || option.value.toLowerCase().includes(query),
+  )
+}

--- a/src/app/test/unit/utils/form.test.ts
+++ b/src/app/test/unit/utils/form.test.ts
@@ -275,6 +275,95 @@ describe('buildFormTreeFromSchema', () => {
     })
   })
 
+  test('handle relation options from editor options for relation input', () => {
+    // `relation` is not part of `EditorOptions` in @nuxt/content yet, but
+    // `.editor()` forwards its whole argument to the generated schema.
+    const schema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      $ref: '#/definitions/events',
+      definitions: {
+        events: {
+          type: 'object',
+          properties: {
+            meetupLocation: {
+              type: 'string',
+              $content: {
+                editor: {
+                  input: 'relation',
+                  relation: {
+                    collection: 'meetupLocations',
+                    labelField: 'name',
+                  },
+                },
+              },
+            },
+          },
+          additionalProperties: false,
+          required: [],
+        },
+      },
+    } as unknown as Draft07
+
+    expect(buildFormTreeFromSchema('events', schema)).toStrictEqual({
+      events: {
+        id: '#events',
+        type: 'object',
+        title: 'Events',
+        children: {
+          meetupLocation: {
+            id: '#events/meetupLocation',
+            type: 'relation',
+            title: 'MeetupLocation',
+            relation: {
+              collection: 'meetupLocations',
+              labelField: 'name',
+            },
+          },
+        },
+      },
+    })
+  })
+
+  test('ignore relation options without a target collection', () => {
+    const schema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      $ref: '#/definitions/events',
+      definitions: {
+        events: {
+          type: 'object',
+          properties: {
+            meetupLocation: {
+              type: 'string',
+              $content: {
+                editor: {
+                  input: 'relation',
+                  relation: { labelField: 'name' },
+                },
+              },
+            },
+          },
+          additionalProperties: false,
+          required: [],
+        },
+      },
+    } as unknown as Draft07
+
+    expect(buildFormTreeFromSchema('events', schema)).toStrictEqual({
+      events: {
+        id: '#events',
+        type: 'object',
+        title: 'Events',
+        children: {
+          meetupLocation: {
+            id: '#events/meetupLocation',
+            type: 'relation',
+            title: 'MeetupLocation',
+          },
+        },
+      },
+    })
+  })
+
   test('hide field if set in editor metas', () => {
     const schema: Draft07 = {
       $schema: 'http://json-schema.org/draft-07/schema#',

--- a/src/app/test/unit/utils/relation.test.ts
+++ b/src/app/test/unit/utils/relation.test.ts
@@ -1,0 +1,120 @@
+import type { DatabaseItem } from '../../../src/types'
+import { expect, test, describe } from 'vitest'
+import { relationSlug, relationValue, relationLabel, buildRelationOptions, filterRelationOptions } from '../../../src/utils/relation'
+
+function document(item: Partial<DatabaseItem>): DatabaseItem {
+  return { id: '', stem: '', extension: 'md', ...item } as DatabaseItem
+}
+
+describe('relationSlug', () => {
+  test('uses the document file name', () => {
+    expect(relationSlug(document({ stem: 'people/zsofi-borsi' }))).toBe('zsofi-borsi')
+  })
+
+  test('handles a document at the source root', () => {
+    expect(relationSlug(document({ stem: 'paris-france' }))).toBe('paris-france')
+  })
+
+  test('returns an empty string when the document has no stem', () => {
+    expect(relationSlug(document({}))).toBe('')
+  })
+})
+
+describe('relationValue', () => {
+  test('falls back to the file name when the document has no slug field', () => {
+    expect(relationValue(document({ stem: 'people/zsofi-borsi' }))).toBe('zsofi-borsi')
+  })
+
+  test('prefers a slug defined by the document itself', () => {
+    expect(relationValue(document({ stem: 'meetup-locations/paris', slug: 'paris-france' }))).toBe('paris-france')
+  })
+
+  test('reads the requested field', () => {
+    const item = document({ stem: 'people/zsofi-borsi', path: '/people/zsofi-borsi' })
+
+    expect(relationValue(item, 'path')).toBe('/people/zsofi-borsi')
+    expect(relationValue(item, 'stem')).toBe('people/zsofi-borsi')
+  })
+
+  test('stringifies numbers', () => {
+    expect(relationValue(document({ order: 3 }), 'order')).toBe('3')
+  })
+
+  test('returns an empty string for a missing non-slug field', () => {
+    expect(relationValue(document({ stem: 'people/zsofi-borsi' }), 'path')).toBe('')
+  })
+})
+
+describe('relationLabel', () => {
+  test('uses the requested field', () => {
+    expect(relationLabel(document({ name: 'Zsófi Borsi' }), 'zsofi-borsi', 'name')).toBe('Zsófi Borsi')
+  })
+
+  test('falls back to the usual title fields', () => {
+    expect(relationLabel(document({ title: 'Paris, France' }), 'paris-france', 'name')).toBe('Paris, France')
+    expect(relationLabel(document({ name: 'Paris, France' }), 'paris-france')).toBe('Paris, France')
+  })
+
+  test('falls back to the value so a row is never blank', () => {
+    expect(relationLabel(document({ name: '  ' }), 'zsofi-borsi', 'name')).toBe('zsofi-borsi')
+  })
+})
+
+describe('buildRelationOptions', () => {
+  test('maps documents to sorted options', () => {
+    const items = [
+      document({ stem: 'people/zsofi-borsi', name: 'Zsófi Borsi' }),
+      document({ stem: 'people/alice-doe', name: 'Alice Doe' }),
+    ]
+
+    expect(buildRelationOptions(items, { collection: 'people', labelField: 'name' })).toStrictEqual([
+      { value: 'alice-doe', label: 'Alice Doe' },
+      { value: 'zsofi-borsi', label: 'Zsófi Borsi' },
+    ])
+  })
+
+  test('drops documents with no referenceable value', () => {
+    const items = [
+      document({ stem: 'people/alice-doe', name: 'Alice Doe' }),
+      document({ stem: '', name: 'Nameless' }),
+    ]
+
+    expect(buildRelationOptions(items, { collection: 'people', labelField: 'name' })).toStrictEqual([
+      { value: 'alice-doe', label: 'Alice Doe' },
+    ])
+  })
+
+  test('deduplicates values', () => {
+    const items = [
+      document({ stem: 'people/alice-doe', name: 'Alice Doe' }),
+      document({ stem: 'team/alice-doe', name: 'Alice Doe (team)' }),
+    ]
+
+    expect(buildRelationOptions(items, { collection: 'people', labelField: 'name' })).toStrictEqual([
+      { value: 'alice-doe', label: 'Alice Doe' },
+    ])
+  })
+})
+
+describe('filterRelationOptions', () => {
+  const options = [
+    { value: 'alice-doe', label: 'Alice Doe' },
+    { value: 'zsofi-borsi', label: 'Zsófi Borsi' },
+  ]
+
+  test('returns every option when the search is empty', () => {
+    expect(filterRelationOptions(options, '  ')).toStrictEqual(options)
+  })
+
+  test('matches on the label', () => {
+    expect(filterRelationOptions(options, 'alice')).toStrictEqual([options[0]])
+  })
+
+  test('matches on the stored value', () => {
+    expect(filterRelationOptions(options, 'borsi')).toStrictEqual([options[1]])
+  })
+
+  test('returns nothing when no option matches', () => {
+    expect(filterRelationOptions(options, 'nobody')).toStrictEqual([])
+  })
+})


### PR DESCRIPTION
Adds a `relation` form input so a string field can reference a document of
another collection, and editors pick it from a searchable list instead of typing
an identifier by hand.

A first step towards #219, which asks for the full feature (arrays, multiple
target collections, MDC props) — see [Follow-ups](#follow-ups) for what is left.
Deliberately not using a closing keyword, so the issue stays open for the rest.

#307 was closed in favour of #219 and asked for the same thing. It proposed an
async `options` callback on the field; that cannot work, because the options
would have to survive serialisation into the generated JSON Schema that Studio
reads at edit time. Naming the target collection declaratively keeps the schema
static and lets Studio resolve the documents itself.

### Why

Cross-collection references are a common content model (`post.author` →
`authors`, `event.location` → `locations`). Today they render as free-text
fields, so editors copy-paste slugs and a typo is only caught later, by a build
or an integrity check. `z.enum()` built from the target collection is the usual
workaround, but it renders a closed dropdown and couples the schema to the data.

### API

```ts
// content.config.ts
author: property(z.string()).editor({
  input: 'relation',
  relation: { collection: 'authors', labelField: 'name' },
})
```

- `collection` — name of the referenced collection. Both `page` and `data` collections work.
- `valueField` — field written to the file. Defaults to `slug`, the document file
  name, which is what a document is usually referenced by. `path` and `stem` are
  also available, as is any field of the referenced document.
- `labelField` — field displayed in the picker. Defaults to `name`, then `title`,
  then the stored value.

### How it works

`InputRelation.vue` mirrors `InputMedia.vue`: a text input plus a searchable
popover. Options come from the existing host bridge — `host.document.db.list()`
filtered by `host.collection.getByFsPath()` — so there is no new server route
and nothing external to reach. Search matches both the label and the stored
value, so editors can look up a display name or a slug they already know.

The leading icon reports whether the current value resolves to a document, which
is the main thing a picker can offer over a text field.

### Backward compatibility

- The field keeps storing a plain string. File format, content queries and
  existing documents are untouched, and the value stays editable by hand.
- A value matching no document is flagged but never rewritten.
- Fields without `input: 'relation'` are unaffected; an unknown `input` already
  falls back to `InputText`, so an older Studio reading a newer schema degrades
  to a text field.

### `EditorOptions` in `@nuxt/content`

`.editor()` forwards its whole argument into `$content.editor` in the generated
schema, so `relation` reaches Studio at runtime with no change to
`@nuxt/content`. Only the types need widening: `EditorOptions.input` is the
closed union `'media' | 'icon' | 'textarea'`, so `input: 'relation'` currently
needs a cast (as in the playground here). That is lifted by the companion PR on
`nuxt/content`: nuxt/content#3840.

### Follow-ups

Deliberately left out to keep this reviewable:

- **Arrays of references** (`z.array(z.string())`). The array branch of
  `buildFormTreeFromSchema` hardcodes `type: 'array'` and drops the parent's
  `editor.input`, and `InputArray.vue` gives string arrays a badge path that
  bypasses `InputWrapper`. That is the same gap as #374 / #518, so it seemed
  better handled on top of that work than alongside it.
- Multiple target collections (`collection: ['blog', 'changelog']` from #219).
- Documents created in the current unpublished session are not offered until
  they are saved, since options come from the indexed database.
- References in MDC component props.

### Test plan

- `src/app/test/unit/utils/relation.test.ts` — new, 18 cases covering value and
  label resolution, option building and search.
- `src/app/test/unit/utils/form.test.ts` — 2 cases for the schema → form tree
  mapping, including a relation with no target collection.
- `pnpm verify` passes: lint clean, `nuxt typecheck` and
  `vue-tsc -p src/app/tsconfig.app.json` clean, 413 tests green, `pnpm test:types`
  clean.
- Exercised in `playground/docus`, where `docs.author` now references the
  existing `authors` data collection.
